### PR TITLE
Add plotly.js based charting tool and associated documentation

### DIFF
--- a/lib/components/plots/css-override.css
+++ b/lib/components/plots/css-override.css
@@ -1,0 +1,3 @@
+.modebar-group {
+  display: flex !important;
+}

--- a/lib/components/plots/plotly.jsx
+++ b/lib/components/plots/plotly.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useCallback, forwardRef } from "react";
+import clsx from "clsx";
+import Plotly from "plotly.js-dist";
+import "./css-override.css";
+
+const hoverHandler = (callback) => (data) => {
+  callback && callback(data);
+};
+
+const Plot = forwardRef(function InternalPlot(
+  {
+    data = [],
+    layout = {},
+    config = {},
+    revision = 0,
+    className = "",
+    onHover,
+  },
+  ref
+) {
+  if (!ref) ref = useRef(null);
+
+  const handleHover = useCallback(hoverHandler(onHover));
+
+  useEffect(() => {
+    if (!ref.current) return;
+    Plotly.newPlot(ref.current, data, layout, config);
+    ref.current.on("plotly_hover", handleHover);
+  }, [ref.current]);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    Plotly.newPlot(ref.current, data, layout, config);
+    ref.current.on("plotly_hover", handleHover);
+  }, [data, layout, config, revision]);
+
+  return <div ref={ref} className={clsx("w-full", className)}></div>;
+});
+
+export default Plot;
+export { Plot };

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -35,3 +35,6 @@ export * from "./components/display/accordion";
 export { Input } from "./components/form/input";
 export * from "./components/form/fieldset";
 export * from "./components/form/textarea";
+
+// data visualization
+export { Plot } from "./components/plots/plotly";

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@headlessui/react": "^2.0.0-alpha.4",
         "clsx": "^2.1.0",
         "internal-nav-helper": "^3.1.0",
+        "plotly.js-dist": "^2.30.1",
         "react-icons": "^5.0.1",
         "redux-bundler": "^28.1.0",
         "redux-bundler-hook": "^1.0.3",
@@ -4020,6 +4021,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/plotly.js-dist": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-2.30.1.tgz",
+      "integrity": "sha512-Ta0HV6IvEE8auL6EgYMATsG58k+9ypva2Ti3YDGyau0ec9AqH4hZAryyxTcBkWC+jqpasVqSD1khpFByDLrvqg=="
     },
     "node_modules/postcss": {
       "version": "8.4.33",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@headlessui/react": "^2.0.0-alpha.4",
     "clsx": "^2.1.0",
     "internal-nav-helper": "^3.1.0",
+    "plotly.js-dist": "^2.30.1",
     "react-icons": "^5.0.1",
     "redux-bundler": "^28.1.0",
     "redux-bundler-hook": "^1.0.3",

--- a/src/app-bundles/route-bundle.js
+++ b/src/app-bundles/route-bundle.js
@@ -38,6 +38,8 @@ import FieldsetDocs from "../app-pages/documentation/forms/fieldset";
 import TextareaDocs from "../app-pages/documentation/forms/textarea";
 import Logout from "../app-pages/logout";
 import LoginButtonDocs from "../app-pages/documentation/buttons/login-button";
+import Plots from "../app-pages/documentation/plots";
+import PlotlyWrapperDocs from "../app-pages/documentation/plots/plotly-wrapper";
 
 export default createRouteBundle(
   {
@@ -74,6 +76,8 @@ export default createRouteBundle(
     "/docs/forms/date-time-inputs": DateTimeInputDocs,
     "/docs/forms/file-input": FileInputDocs,
     "/docs/water-management": WaterManagement,
+    "/docs/plots": Plots,
+    "/docs/plots/plotly-wrapper": PlotlyWrapperDocs,
     "/docs/types": Types,
     "/docs/types/link": LinkDocs,
     "/docs/types/tab": TabDocs,

--- a/src/app-pages/documentation/plots/heatmap.jsx
+++ b/src/app-pages/documentation/plots/heatmap.jsx
@@ -1,0 +1,106 @@
+import { useCallback, useState } from "react";
+import { UsaceBox, Code, Text, Plot, Button } from "../../../../lib";
+import { CodeExample } from "../../../app-components/code-example";
+import PropsTable from "../../../app-components/props-table";
+import DocsPage from "../_docs-page";
+
+const pageBreadcrumbs = [
+  {
+    text: "Documentation",
+    href: "/docs",
+  },
+  {
+    text: "Plots",
+    href: "/docs/plots",
+  },
+  {
+    text: "Heatmap",
+    href: "/docs/plots/heatmap",
+  },
+];
+
+const componentProps = [
+  {
+    name: "",
+    type: "",
+    default: "",
+    desc: "",
+  },
+];
+
+function zeroMatrix(rows, cols) {
+  const matrix = [];
+  for (let i = 0; i < rows; i++) {
+    matrix.push(Array(cols).fill(0));
+  }
+  return matrix;
+}
+
+const trace = {
+  type: "heatmap",
+  hoverinfo: "none",
+  z: zeroMatrix(50, 50),
+};
+
+let lastHover = [null, null];
+
+function HeatmapDocs() {
+  const [revision, setRevision] = useState(0);
+
+  const handleHover = useCallback((hoverData) => {
+    const pt = hoverData?.points[0];
+    const x = pt.x;
+    const y = pt.y;
+    const z = pt.z;
+    if (lastHover[0] === x && lastHover[1] === y) {
+      return;
+    } else {
+      trace.z[y][x] = z + 1;
+      lastHover = [x, y];
+      setRevision(revision + 1);
+    }
+  });
+
+  return (
+    <DocsPage breadcrumbs={pageBreadcrumbs}>
+      <UsaceBox title="Heatmap">
+        {/* Description of the component and what problem it solves */}
+        <div className="pb-6">
+          <Text>Description of component</Text>
+          <Text className="pt-3">Description continued</Text>
+        </div>
+        {/* Example usage - remove if not needed */}
+        <div className="rounded-md border border-dashed px-6 py-3 mb-3">
+          <Plot
+            data={[trace]}
+            layout={{
+              width: 800,
+              height: 500,
+            }}
+            onHover={handleHover}
+            revision={revision}
+          />
+        </div>
+        {/* Example code */}
+        <CodeExample
+          code={`import {  } from "@usace/groundwork";
+
+function Component() {
+  return ()
+}
+
+export default Component;
+`}
+        />
+        {/* Component props documentation */}
+        <div className="font-bold text-lg pt-6">
+          Component API - <Code className="p-2">{`<SiteWrapper />`}</Code>
+        </div>
+        <PropsTable propsList={componentProps} />
+      </UsaceBox>
+    </DocsPage>
+  );
+}
+
+export default HeatmapDocs;
+export { HeatmapDocs };

--- a/src/app-pages/documentation/plots/index.jsx
+++ b/src/app-pages/documentation/plots/index.jsx
@@ -1,0 +1,35 @@
+import { UsaceBox, H4, Text } from "../../../../lib";
+import DocsPage from "../_docs-page";
+
+const pageBreadcrumbs = [
+  {
+    text: "Documentation",
+    href: "/docs",
+  },
+  {
+    text: "Plots",
+    href: "/docs/plots",
+  },
+];
+
+function Plots() {
+  return (
+    <DocsPage breadcrumbs={pageBreadcrumbs}>
+      <UsaceBox title="Plots (sort of)">
+        <Text className="pb-6">
+          We use Plotly.js to create plots in Groundwork. This is a simple
+          wrapper around Plotly.js to make it easier to use.
+        </Text>
+        <H4>Components</H4>
+        <ul>
+          <a className="hover:underline" href="/docs/plots/basic">
+            <li>Basic Plot</li>
+          </a>
+        </ul>
+      </UsaceBox>
+    </DocsPage>
+  );
+}
+
+export default Plots;
+export { Plots };

--- a/src/app-pages/documentation/plots/plotly-wrapper.jsx
+++ b/src/app-pages/documentation/plots/plotly-wrapper.jsx
@@ -1,0 +1,445 @@
+import { useCallback, useState } from "react";
+import { UsaceBox, Code, Text, Plot, H2, H3 } from "../../../../lib";
+import { CodeExample } from "../../../app-components/code-example";
+import PropsTable from "../../../app-components/props-table";
+import DocsPage from "../_docs-page";
+
+const pageBreadcrumbs = [
+  {
+    text: "Documentation",
+    href: "/docs",
+  },
+  {
+    text: "Plots",
+    href: "/docs/plots",
+  },
+  {
+    text: "Plotly.js Wrapper",
+    href: "/docs/plots/plotly-wrapper",
+  },
+];
+
+const componentProps = [
+  {
+    name: "data",
+    type: "array of objects",
+    default: "[]",
+    desc: "Array of data objects, each object represents a trace on the plot. See the Plotly.js documentation for more information.",
+  },
+  {
+    name: "layout",
+    type: "object",
+    default: "{}",
+    desc: "Object representing the layout of the plot. See the Plotly.js documentation for more information.",
+  },
+  {
+    name: "config",
+    type: "object",
+    default: "{}",
+    desc: "Object representing the configuration of the plot. See the Plotly.js documentation for more information.",
+  },
+  {
+    name: "revision",
+    type: "number",
+    default: "0",
+    desc: "A number that when changed will force the plot to redraw. Useful for live updates.",
+  },
+  {
+    name: "onHover",
+    type: "function",
+    default: "null",
+    desc: "A function that will be called when the user hovers over the plot. The function will be passed the hover data.",
+  },
+  {
+    name: "className",
+    type: "string",
+    default: "''",
+    desc: "Additional classes to apply to the plot container.",
+  },
+  {
+    name: "ref",
+    type: "React.RefObject",
+    default: "undefined",
+    desc: "A ref object that can be used to call Plotly methods directly.",
+  },
+];
+
+/**
+ * Data for the basic example
+ */
+var basicTrace1 = {
+  x: [1, 2, 3, 4],
+  y: [10, 15, 13, 17],
+  mode: "markers",
+  type: "scatter",
+};
+
+var basicTrace2 = {
+  x: [2, 3, 4, 5],
+  y: [16, 5, 11, 9],
+  mode: "lines",
+  type: "scatter",
+};
+
+var basicTrace3 = {
+  x: [1, 2, 3, 4],
+  y: [12, 9, 15, 12],
+  mode: "lines+markers",
+  type: "scatter",
+};
+
+const basicLayout = {
+  title: "A Basic Line and Scatter Plot",
+};
+
+/**
+ * Data for the live update example
+ */
+var liveTrace1 = {
+  x: [1],
+  y: [Math.random() * 10],
+  type: "scatter",
+};
+
+var liveTrace2 = {
+  x: [1],
+  y: [Math.random() * 10],
+  type: "scatter",
+};
+
+function addRandomData(cb) {
+  if (liveTrace1.x.length > 20) {
+    liveTrace1.x.shift();
+    liveTrace1.y.shift();
+    liveTrace2.x.shift();
+    liveTrace2.y.shift();
+  }
+  liveTrace1.x = [...liveTrace1.x, liveTrace1.x[liveTrace1.x.length - 1] + 1];
+  liveTrace1.y = [...liveTrace1.y, Math.random() * 10];
+  liveTrace2.x = [...liveTrace2.x, liveTrace2.x[liveTrace2.x.length - 1] + 1];
+  liveTrace2.y = [...liveTrace2.y, Math.random() * 10];
+  cb && cb();
+}
+
+const liveTraceLayout = {
+  title: "A Fancy Plot",
+};
+
+// place to hold our interval outside of the component scope
+var interval;
+
+/**
+ * Data for the custom user interaction example
+ */
+function zeroMatrix(rows, cols) {
+  const matrix = [];
+  for (let i = 0; i < rows; i++) {
+    matrix.push(Array(cols).fill(0));
+  }
+  return matrix;
+}
+
+const heatTrace = {
+  type: "heatmap",
+  hoverinfo: "none",
+  z: zeroMatrix(50, 50),
+};
+
+let lastHover = [null, null];
+
+const heatTraceLayout = {
+  title: "A Silly Heatmap",
+};
+
+/**
+ * Shared configuration for all plots
+ */
+const sharedConfig = {
+  displaylogo: false,
+};
+
+function PlotlyWrapperDocs() {
+  const [liveRevision, setLiveRevision] = useState(0);
+  const [heatmapRevision, setHeatmapRevision] = useState(0);
+
+  /**
+   * Setup the live update interval, just loads dummy data on some interval
+   */
+  if (interval) window.clearInterval(interval);
+  interval = window.setInterval(() => {
+    addRandomData(() => {
+      setLiveRevision(liveRevision + 1);
+    });
+  }, 1000);
+
+  /**
+   * Setup for the heatmap hover event
+   */
+  const handleHover = useCallback((hoverData) => {
+    const pt = hoverData?.points[0];
+    const x = pt.x;
+    const y = pt.y;
+    const z = pt.z;
+    if (lastHover[0] === x && lastHover[1] === y) {
+      return;
+    } else {
+      heatTrace.z[y][x] = z + 1;
+      lastHover = [x, y];
+      setHeatmapRevision(heatmapRevision + 1);
+    }
+  });
+
+  return (
+    <DocsPage breadcrumbs={pageBreadcrumbs}>
+      <UsaceBox title="Plotly.js Wrapper">
+        {/* Description of the component and what problem it solves */}
+        <div className="pb-6">
+          <Text>
+            Our <Code>{`<Plot/>`}</Code> component is a pretty simple wrapper
+            around the popular Plotly.js library. Plotly started as a Python
+            plotting library and has expanded into a number of supported
+            languages. There are a lot of things you can do with Plotly, way
+            more than we could document here, so below are some examples of
+            using our component, but you should review the{" "}
+            <a
+              href="https://plotly.com/javascript/"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              Plotly.js documentation
+            </a>{" "}
+            in order to get a full understanding of the API.
+          </Text>
+          <Text className="pt-3">
+            The data, layout and config props map directly to the options
+            exposed in the{" "}
+            <Code>{`Plotly.newPlot(el, data, layout, config)`}</Code> function.
+            There are a couple of additional props that we've added to make it
+            easier to update the plot when data changes (revision) and to handle
+            various events. If you want low-level control over the plot, you can
+            pass a ref to the Plot component and call Plotly methods directly.
+          </Text>
+        </div>
+
+        {/* Example usage - remove if not needed */}
+        <H3 className="pt-6 pb-3">Basic Plot</H3>
+        <Text className="pb-3">
+          A sample chart right off of the{" "}
+          <a
+            className="underline"
+            target="_blank"
+            rel="noreferrer"
+            href="https://plotly.com/javascript/line-and-scatter/"
+          >
+            Plotly example page
+          </a>
+          .
+        </Text>
+        <div className="rounded-md border border-dashed px-6 py-3 mb-3">
+          <Plot
+            data={[basicTrace1, basicTrace2, basicTrace3]}
+            layout={basicLayout}
+            config={sharedConfig}
+          />
+        </div>
+        {/* Example code */}
+        <CodeExample
+          code={`import { Plot } from "@usace/groundwork";
+
+let trace1 = {
+  x: [1, 2, 3, 4],
+  y: [10, 15, 13, 17],
+  mode: "markers",
+  type: "scatter",
+};
+
+let trace2 = {
+  x: [2, 3, 4, 5],
+  y: [16, 5, 11, 9],
+  mode: "lines",
+  type: "scatter",
+};
+
+let trace3 = {
+  x: [1, 2, 3, 4],
+  y: [12, 9, 15, 12],
+  mode: "lines+markers",
+  type: "scatter",
+};
+
+const basicLayout = {
+  title: "A Basic Line and Scatter Plot",
+};
+
+const config = {
+  displaylogo: false,
+};
+
+function Component() {
+  return (
+    <Plot
+      data={[trace1, trace2, trace3]}
+      layout={layout}
+      config={config}
+    />
+  )
+}
+
+export default Component;
+`}
+        />
+
+        {/* Example usage - remove if not needed */}
+        <H3 className="pt-6 pb-3">Live Updates</H3>
+        <div className="rounded-md border border-dashed px-6 py-3 mb-3">
+          <Plot
+            revision={liveRevision}
+            data={[liveTrace1, liveTrace2]}
+            layout={liveTraceLayout}
+            config={sharedConfig}
+          />
+        </div>
+        {/* Example code */}
+        <CodeExample
+          code={`import { Plot } from "@usace/groundwork";
+import { useState } from "react";
+
+var trace1 = {
+  x: [1],
+  y: [Math.random() * 10],
+  type: "scatter",
+};
+
+var trace2 = {
+  x: [1],
+  y: [Math.random() * 10],
+  type: "scatter",
+};
+
+const layout = {
+  title: "A Fancy Plot",
+};
+
+const config = {
+  displaylogo: false,
+};
+
+function addRandomData(callback) {
+  if (trace1.x.length > 20) {
+    trace1.x.shift();
+    trace1.y.shift();
+    trace2.x.shift();
+    trace2.y.shift();
+  }
+  trace1.x = [...trace1.x, trace1.x[trace1.x.length - 1] + 1];
+  trace1.y = [...trace1.y, Math.random() * 10];
+  trace2.x = [...trace2.x, trace2.x[trace2.x.length - 1] + 1];
+  trace2.y = [...trace2.y, Math.random() * 10];
+  callback && callback();
+}
+
+let interval;
+
+function Component() {
+  const [revision, setRevision] = useState(0);
+
+  if (interval) window.clearInterval(interval);
+  interval = window.setInterval(() => {
+    addRandomData(() => {
+      setRevision(revision + 1);
+    });
+  }, 1000);
+
+  return (
+    <Plot
+      revision={revision}
+      data={[trace1, trace2]}
+      layout={layout}
+      config={config}
+    />
+  )
+}
+
+export default Component;
+`}
+        />
+
+        {/* Example usage - remove if not needed */}
+        <H3 className="pt-6 pb-3">Custom User Interaction</H3>
+        <Text className="pb-3">
+          When you want a heatmap but don't have data, let the user create one
+          themselves. Each cell counts the number of times it has been hovered
+          over and the color will update accordingly. Have fun making some pixel
+          art!
+        </Text>
+        <div className="rounded-md border border-dashed px-6 py-3 mb-3">
+          <Plot
+            revision={heatmapRevision}
+            data={[heatTrace]}
+            layout={heatTraceLayout}
+            config={sharedConfig}
+            onHover={handleHover}
+          />
+        </div>
+        {/* Example code */}
+        <CodeExample
+          code={`import { Plot } from "@usace/groundwork";
+import { useCallback, useState } from "react";
+
+const trace = {
+  type: "heatmap",
+  hoverinfo: "none",
+  z: zeroMatrix(50, 50),  //custom function to create a 50x50 matrix of 0s
+};
+
+let lastHover = [null, null];
+
+const layout = {
+  title: "A Silly Heatmap",
+};
+
+function Component() {
+  const [revision, setRevision] = useState(0);
+
+  const handleHover = useCallback((hoverData) => {
+    const pt = hoverData?.points[0];
+    const x = pt.x;
+    const y = pt.y;
+    const z = pt.z;
+    if (lastHover[0] === x && lastHover[1] === y) {
+      return;
+    } else {
+      trace.z[y][x] = z + 1;
+      lastHover = [x, y];
+      setRevision(revision + 1);
+    }
+  });
+
+  return (
+    <Plot
+      revision={revision}
+      data={[trace]}
+      layout={layout}
+      config={config}
+      onHover={handleHover}
+    />
+  )
+}
+
+export default Component;
+`}
+        />
+
+        {/* Component props documentation */}
+        <div className="font-bold text-lg pt-6">
+          Component API - <Code className="p-2">{`<Plot />`}</Code>
+        </div>
+        <PropsTable propsList={componentProps} />
+      </UsaceBox>
+    </DocsPage>
+  );
+}
+
+export default PlotlyWrapperDocs;
+export { PlotlyWrapperDocs };

--- a/src/nav-links.js
+++ b/src/nav-links.js
@@ -172,6 +172,18 @@ export default [
     href: "/docs/water-management",
   },
   {
+    id: "plots",
+    text: "Plots",
+    href: "/docs/plots",
+    children: [
+      {
+        id: "plotly-wrapper",
+        text: "Plotly.js Wrapper",
+        href: "/docs/plots/plotly-wrapper",
+      },
+    ],
+  },
+  {
     id: "types",
     text: "Types",
     href: "/docs/types",


### PR DESCRIPTION
This might bloat the lib a little bit but we're going to need charts, so added plotly as an option.  We could also add other charting libs if we want, just will need to figure out some tree-shaking as we add more things that may or may not get used.