### PR TITLE
bump version to 2.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@usace/groundwork",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@usace/groundwork",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^2.0.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@usace/groundwork",
   "private": false,
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "type": "module",
   "main": "./dist/groundwork.umd.cjs",


### PR DESCRIPTION
might regret adding the merge protections for this type of case, will look into some sort of alternative to manual version bumping.