### PR TITLE
CDA Latest Value Card Component

### DIFF
--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -66,7 +66,7 @@ const CdaLatestValueCard = ({
     <Card className={className} {...props}>
       <div className="gw-flex gw-items-center gw-justify-between">
         <p className="gw-font-lg gw-truncate gw-text-lg gw-font-semibold gw-text-black">
-          {label}
+          {label ?? tsId}
         </p>
         {tsFetching | (catalog.isPending && enableCatalog) ? (
           <Skeleton className="gw-w-20" />

--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -8,6 +8,7 @@ const CdaLatestValueCard = ({
   label,
   tsId,
   office,
+  unit,
   digits = 0,
   className,
   cdaUrl,
@@ -25,6 +26,7 @@ const CdaLatestValueCard = ({
     cdaParams: {
       name: tsId,
       office,
+      ...(unit && { unit }),
       ...(begin && { begin }),
       ...(end && { end }),
     },

--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -3,7 +3,14 @@ import { MdErrorOutline } from "react-icons/md";
 import { PiClockThin } from "react-icons/pi";
 import { getLatestEntry } from "./cda";
 
-const CdaLatestValueCard = ({ label, tsId, office, digits = 0, className }) => {
+const CdaLatestValueCard = ({
+  label,
+  tsId,
+  office,
+  digits = 0,
+  className,
+  ...props
+}) => {
   const { data, isPending, isError } = useCdaTimeSeries({
     cdaParams: { name: tsId, office },
   });
@@ -19,7 +26,7 @@ const CdaLatestValueCard = ({ label, tsId, office, digits = 0, className }) => {
   }
 
   return (
-    <Card className={className}>
+    <Card className={className} {...props}>
       <div className="gw-flex gw-items-center gw-justify-between">
         <p className="gw-font-lg gw-truncate gw-text-lg gw-font-semibold gw-text-black">
           {label}

--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -10,9 +10,7 @@ const CdaLatestValueCard = ({
   office,
   digits = 0,
   className,
-  cdaParams,
   cdaUrl,
-  queryOptions,
   ...props
 }) => {
   const [latestDate, setLatestDate] = useState();
@@ -25,14 +23,12 @@ const CdaLatestValueCard = ({
     isError: tsIsError,
   } = useCdaTimeSeries({
     cdaParams: {
-      ...cdaParams,
       name: tsId,
       office,
       ...(begin && { begin }),
       ...(end && { end }),
     },
     cdaUrl: cdaUrl,
-    queryOptions: queryOptions,
   });
 
   const enableCatalog = !tsPending && data?.values.length == 0;

--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -1,0 +1,99 @@
+import { Card, Skeleton, useCdaTimeSeries } from "../../index";
+import { MdErrorOutline } from "react-icons/md";
+import { PiClockThin } from "react-icons/pi";
+import { getLatestEntry } from "./cda";
+
+const CdaLatestValueCard = ({ label, tsId, office, digits = 0, className }) => {
+  const { data, isPending, isError } = useCdaTimeSeries({
+    cdaParams: { name: tsId, office },
+  });
+
+  let latestEntry = undefined;
+
+  if (data) latestEntry = getLatestEntry(data);
+
+  return (
+    <Card className={className}>
+      <div className="gw-flex gw-items-center gw-justify-between">
+        <p className="gw-font-lg gw-truncate gw-text-lg gw-font-semibold gw-text-black">
+          {label}
+        </p>
+        {isError ? (
+          <span className="gw-text-lg">
+            <MdErrorOutline />
+          </span>
+        ) : isPending ? (
+          <Skeleton className="gw-w-20" />
+        ) : (
+          <CardValue
+            value={latestEntry[1]}
+            units={data.units}
+            digits={digits}
+          />
+        )}
+      </div>
+      <div className="gw-mt-2 gw-flex gw-justify-between">
+        {isError ? (
+          <span className="gw-text-red-500">Error retrieving data</span>
+        ) : isPending ? (
+          <Skeleton className="gw-w-48" />
+        ) : (
+          <>
+            <CardTimestamp datetime={new Date(latestEntry[0])} />
+            {/* {change ? <Parameter24hrChange change={change} /> : customBotRight} */}
+          </>
+        )}
+      </div>
+    </Card>
+  );
+};
+
+const CardTimestamp = ({ datetime }) => {
+  return (
+    <div className="sm:gw-flex">
+      <p className="gw-flex gw-items-center gw-text-sm gw-text-gray-500">
+        <PiClockThin
+          className="gw-mr-1.5 gw-h-5 gw-w-5 gw-flex-shrink-0 gw-text-gray-600"
+          aria-hidden="true"
+        />
+        {datetime ? (
+          <time dateTime={datetime.toISOString()}>
+            {datetime &&
+              datetime.toLocaleString("en-US", {
+                day: "numeric",
+                year: "numeric", // numeric, 2-digit
+                month: "short", // numeric, 2-digit, long, short, narrow
+                hour: "numeric", // numeric, 2-digit
+                minute: "numeric", // numeric, 2-digit
+                // second: 'numeric', // numeric, 2-digit
+                timeZoneName: "short",
+              })}
+          </time>
+        ) : (
+          <span>-</span>
+        )}
+      </p>
+    </div>
+  );
+};
+
+const CardValue = ({ value, units, digits = 0 }) => {
+  return (
+    <div className="gw-ml-2 gw-flex gw-flex-shrink-0">
+      <p className="gw-inline-flex gw-px-2 gw-t-ext-lg gw-font-semibold gw-leading-5 gw-text-black">
+        {typeof value === "number"
+          ? value.toLocaleString(undefined, {
+              minimumFractionDigits: digits,
+              maximumFractionDigits: digits,
+            })
+          : "-"}
+        <span className="gw-ml-1 gw-text-sm gw-font-normal gw-text-gray-400">
+          {units}
+        </span>
+      </p>
+    </div>
+  );
+};
+
+export { CdaLatestValueCard };
+export default CdaLatestValueCard;

--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -9,10 +9,15 @@ const CdaLatestValueCard = ({
   office,
   digits = 0,
   className,
+  cdaParams,
+  cdaUrl,
+  queryOptions,
   ...props
 }) => {
   const { data, isPending, isError } = useCdaTimeSeries({
-    cdaParams: { name: tsId, office },
+    cdaParams: { cdaParams, name: tsId, office },
+    cdaUrl: cdaUrl,
+    queryOptions: queryOptions,
   });
 
   let latestEntry = undefined;
@@ -49,7 +54,7 @@ const CdaLatestValueCard = ({
         {isError ? (
           <span className="gw-text-red-500">Error retrieving data</span>
         ) : noData ? (
-          <span>No data found.</span>
+          <span>No data found</span>
         ) : isPending ? (
           <Skeleton className="gw-w-48" />
         ) : (

--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -21,6 +21,7 @@ const CdaLatestValueCard = ({
   const {
     data,
     isPending: tsPending,
+    isFetching: tsFetching,
     isError: tsIsError,
   } = useCdaTimeSeries({
     cdaParams: {
@@ -34,11 +35,13 @@ const CdaLatestValueCard = ({
     queryOptions: queryOptions,
   });
 
+  const enableCatalog = !tsPending && data.values.length == 0;
+
   const catalog = useCdaCatalogTS({
     cdaParams: { office, like: tsId },
     cdaUrl: cdaUrl,
     queryOptions: {
-      enabled: !tsPending && data.values.length == 0,
+      enabled: enableCatalog,
     },
   });
 
@@ -67,12 +70,12 @@ const CdaLatestValueCard = ({
         <p className="gw-font-lg gw-truncate gw-text-lg gw-font-semibold gw-text-black">
           {label}
         </p>
-        {tsIsError | noData ? (
+        {tsFetching | (catalog.isPending && enableCatalog) ? (
+          <Skeleton className="gw-w-20" />
+        ) : tsIsError | noData ? (
           <span className="gw-text-lg">
             <MdErrorOutline />
           </span>
-        ) : tsPending ? (
-          <Skeleton className="gw-w-20" />
         ) : (
           <CardValue
             value={latestEntry[1]}
@@ -82,12 +85,12 @@ const CdaLatestValueCard = ({
         )}
       </div>
       <div className="gw-mt-2 gw-flex gw-justify-between">
-        {tsIsError ? (
+        {tsFetching | (catalog.isPending && enableCatalog) ? (
+          <Skeleton className="gw-w-48" />
+        ) : tsIsError ? (
           <span className="gw-text-red-500">Error retrieving data</span>
         ) : noData ? (
           <span>No data found</span>
-        ) : tsPending ? (
-          <Skeleton className="gw-w-48" />
         ) : (
           <>
             <CardTimestamp datetime={new Date(latestEntry[0])} />

--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -35,7 +35,7 @@ const CdaLatestValueCard = ({
     queryOptions: queryOptions,
   });
 
-  const enableCatalog = !tsPending && data.values.length == 0;
+  const enableCatalog = !tsPending && data?.values.length == 0;
 
   const catalog = useCdaCatalogTS({
     cdaParams: { office, like: tsId },

--- a/lib/components/water-management/CdaLatestValueCard.jsx
+++ b/lib/components/water-management/CdaLatestValueCard.jsx
@@ -9,8 +9,14 @@ const CdaLatestValueCard = ({ label, tsId, office, digits = 0, className }) => {
   });
 
   let latestEntry = undefined;
-
-  if (data) latestEntry = getLatestEntry(data);
+  let noData = false;
+  if (data) {
+    if (data.values.length > 0) {
+      latestEntry = getLatestEntry(data);
+    } else {
+      noData = true;
+    }
+  }
 
   return (
     <Card className={className}>
@@ -18,7 +24,7 @@ const CdaLatestValueCard = ({ label, tsId, office, digits = 0, className }) => {
         <p className="gw-font-lg gw-truncate gw-text-lg gw-font-semibold gw-text-black">
           {label}
         </p>
-        {isError ? (
+        {isError | noData ? (
           <span className="gw-text-lg">
             <MdErrorOutline />
           </span>
@@ -35,6 +41,8 @@ const CdaLatestValueCard = ({ label, tsId, office, digits = 0, className }) => {
       <div className="gw-mt-2 gw-flex gw-justify-between">
         {isError ? (
           <span className="gw-text-red-500">Error retrieving data</span>
+        ) : noData ? (
+          <span>No data found.</span>
         ) : isPending ? (
           <Skeleton className="gw-w-48" />
         ) : (

--- a/lib/components/water-management/cda.js
+++ b/lib/components/water-management/cda.js
@@ -16,3 +16,21 @@ export const buildRequest = (endpoint, paramStr, cdaUrl) => {
   const cdaRequest = baseCdaUrl + endpoint + "?" + paramStr;
   return cdaRequest;
 };
+
+/**
+ * Retrieve the chronologically-last entry returned from a CDA TimeSeries GET request.
+ * @param {object} cdaTimeSeries A valid CDA TimeSeries GET response.
+ * @returns {[number, number, number]} The last CDA TimeSeries entry.
+ */
+export const getLatestEntry = (cdaTimeSeries) => {
+  return cdaTimeSeries.values.filter((entry) => entry[1] !== null).slice(-1)[0];
+};
+
+/**
+ * Retrieve the chronologically-last value returned from a CDA TimeSeries GET request.
+ * @param {object} cdaTimeSeries A valid CDA TimeSeries GET response.
+ * @returns {number} The last CDA TimeSeries value.
+ */
+export const getLatestValue = (cdaTimeSeries) => {
+  return getLatestEntry(cdaTimeSeries)[1];
+};

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -41,6 +41,7 @@ export * from "./components/form/textarea";
 export { Plot } from "./components/plots/plotly";
 
 // water management
+export { CdaLatestValueCard } from "./components/water-management/CdaLatestValueCard";
 export { useCdaTimeSeries } from "./components/water-management/useCdaTimeSeries";
 export { useCdaCatalogTS } from "./components/water-management/useCdaCatalogTS";
 export { useCdaLocation } from "./components/water-management/useCdaLocation";

--- a/src/app-bundles/route-bundle.js
+++ b/src/app-bundles/route-bundle.js
@@ -20,7 +20,7 @@ import TableDocs from "../app-pages/documentation/display/table";
 import HeroDocs from "../app-pages/documentation/display/hero";
 import WaterManagement from "../app-pages/documentation/water-management";
 import DataHooks from "../app-pages/documentation/water-management/data-hooks";
-import CdaLatestValueCardDocs from "../app-pages/documentation/water-management/latest-value-card";
+import CdaLatestValueCardDocs from "../app-pages/documentation/water-management/cda-latest-value-card";
 import UseCdaCatalogTS from "../app-pages/documentation/water-management/use-cda-catalog-ts";
 import UseCdaLocation from "../app-pages/documentation/water-management/use-cda-location";
 import UseCdaTimeSeries from "../app-pages/documentation/water-management/use-cda-time-series";
@@ -84,7 +84,7 @@ export default createRouteBundle(
     "/docs/forms/file-input": FileInputDocs,
     "/docs/water-management": WaterManagement,
     "/docs/water-management/data-hooks": DataHooks,
-    "/docs/water-management/latest-value-card": CdaLatestValueCardDocs,
+    "/docs/water-management/cda-latest-value-card": CdaLatestValueCardDocs,
     "/docs/water-management/use-cda-catalog-ts": UseCdaCatalogTS,
     "/docs/water-management/use-cda-location": UseCdaLocation,
     "/docs/water-management/use-cda-time-series": UseCdaTimeSeries,

--- a/src/app-bundles/route-bundle.js
+++ b/src/app-bundles/route-bundle.js
@@ -20,6 +20,7 @@ import TableDocs from "../app-pages/documentation/display/table";
 import HeroDocs from "../app-pages/documentation/display/hero";
 import WaterManagement from "../app-pages/documentation/water-management";
 import DataHooks from "../app-pages/documentation/water-management/data-hooks";
+import CdaLatestValueCardDocs from "../app-pages/documentation/water-management/latest-value-card";
 import UseCdaCatalogTS from "../app-pages/documentation/water-management/use-cda-catalog-ts";
 import UseCdaLocation from "../app-pages/documentation/water-management/use-cda-location";
 import UseCdaTimeSeries from "../app-pages/documentation/water-management/use-cda-time-series";
@@ -83,6 +84,7 @@ export default createRouteBundle(
     "/docs/forms/file-input": FileInputDocs,
     "/docs/water-management": WaterManagement,
     "/docs/water-management/data-hooks": DataHooks,
+    "/docs/water-management/latest-value-card": CdaLatestValueCardDocs,
     "/docs/water-management/use-cda-catalog-ts": UseCdaCatalogTS,
     "/docs/water-management/use-cda-location": UseCdaLocation,
     "/docs/water-management/use-cda-time-series": UseCdaTimeSeries,

--- a/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
@@ -13,8 +13,8 @@ const pageBreadcrumbs = [
     href: "/docs/water-management",
   },
   {
-    text: "LatestValueCard",
-    href: "/docs/water-management/latest-value-card",
+    text: "CdaLatestValueCard",
+    href: "/docs/water-management/cda-latest-value-card",
   },
 ];
 
@@ -85,11 +85,11 @@ const componentProps = [
 function CdaLatestValueCardDocs() {
   return (
     <DocsPage breadcrumbs={pageBreadcrumbs}>
-      <UsaceBox title="CDA Latest Value Card">
+      <UsaceBox title="CdaLatestValueCard">
         {/* Description of the component and what problem it solves */}
         <div className="gw-pb-6">
           <Text>
-            The CDA Latest Value Card can be used to display the most recent
+            The CdaLatestValueCard can be used to display the most recent
             available data for a specific CWMS time series. This component
             assumes that the data has been updated in the past 24 hours.
           </Text>

--- a/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
@@ -2,6 +2,7 @@ import { UsaceBox, Code, CdaLatestValueCard, Text, H3 } from "../../../../lib";
 import { CodeExample } from "../../../app-components/code-example";
 import PropsTable from "../../../app-components/props-table";
 import DocsPage from "../_docs-page";
+import QueryClientWarning from "../../../app-components/water-management/query-client-warning";
 
 const pageBreadcrumbs = [
   {
@@ -93,6 +94,7 @@ function CdaLatestValueCardDocs() {
             available data for a specific CWMS time series. This component
             assumes that the data has been updated in the past 24 hours.
           </Text>
+          <QueryClientWarning />
         </div>
         {/* Example usage - remove if not needed */}
         <H3>Basic Example</H3>

--- a/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
@@ -39,6 +39,12 @@ const componentProps = [
     desc: "The office code of the data's owning office.",
   },
   {
+    name: "unit",
+    type: "string",
+    default: "undefined",
+    desc: "Specifies the unit or unit system of the response. Options: 'EN', 'SI', specific units (e.g. 'ft')",
+  },
+  {
     name: "digits",
     type: "number",
     default: 0,

--- a/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
@@ -23,7 +23,7 @@ const componentProps = [
   {
     name: "label",
     type: "string",
-    default: "undefined",
+    default: "tsId",
     desc: "The label/title of the card.",
   },
   {

--- a/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
@@ -19,19 +19,6 @@ const pageBreadcrumbs = [
   },
 ];
 
-const hookParamsDesc = (
-  <>
-    Additional options for the useCdaTimeSeries hook. See the{" "}
-    <a
-      href="/docs/water-management/use-cda-time-series"
-      className="gw-underline"
-    >
-      useCdaTimeSeries Docs
-    </a>
-    .
-  </>
-);
-
 const componentProps = [
   {
     name: "label",
@@ -64,22 +51,10 @@ const componentProps = [
     desc: "Additional classes to add to the card.",
   },
   {
-    name: "cdaParams",
-    type: "object",
-    default: "undefined",
-    desc: hookParamsDesc,
-  },
-  {
     name: "cdaUrl",
     type: "string",
     default: "undefined",
-    desc: hookParamsDesc,
-  },
-  {
-    name: "queryOptions",
-    type: "object",
-    default: "undefined",
-    desc: hookParamsDesc,
+    desc: "An alternative URL for the CDA instance if not using the default (e.g. for testing in a development environment).",
   },
 ];
 

--- a/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/cda-latest-value-card.jsx
@@ -91,8 +91,14 @@ function CdaLatestValueCardDocs() {
         <div className="gw-pb-6">
           <Text>
             The CdaLatestValueCard can be used to display the most recent
-            available data for a specific CWMS time series. This component
-            assumes that the data has been updated in the past 24 hours.
+            available data for a specific CWMS time series.
+          </Text>
+          <Text className="gw-mt-3">
+            By default, the component assumes the value was updated within the
+            past 24 hours. If not, the component will make a useCatalogTS
+            request to retrieve the date of the latest value and re-run the time
+            series request for that date. Note that the data-fetching process
+            will take longer than normal in this case.
           </Text>
           <QueryClientWarning />
         </div>

--- a/src/app-pages/documentation/water-management/latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/latest-value-card.jsx
@@ -18,6 +18,19 @@ const pageBreadcrumbs = [
   },
 ];
 
+const hookParamsDesc = (
+  <>
+    Additional options for the useCdaTimeSeries hook. See the{" "}
+    <a
+      href="/docs/water-management/use-cda-time-series"
+      className="gw-underline"
+    >
+      useCdaTimeSeries Docs
+    </a>
+    .
+  </>
+);
+
 const componentProps = [
   {
     name: "label",
@@ -48,6 +61,24 @@ const componentProps = [
     type: "string",
     default: "undefined",
     desc: "Additional classes to add to the card.",
+  },
+  {
+    name: "cdaParams",
+    type: "object",
+    default: "undefined",
+    desc: hookParamsDesc,
+  },
+  {
+    name: "cdaUrl",
+    type: "string",
+    default: "undefined",
+    desc: hookParamsDesc,
+  },
+  {
+    name: "queryOptions",
+    type: "object",
+    default: "undefined",
+    desc: hookParamsDesc,
   },
 ];
 

--- a/src/app-pages/documentation/water-management/latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/latest-value-card.jsx
@@ -1,0 +1,109 @@
+import { UsaceBox, Code, CdaLatestValueCard, Text, H3 } from "../../../../lib";
+import { CodeExample } from "../../../app-components/code-example";
+import PropsTable from "../../../app-components/props-table";
+import DocsPage from "../_docs-page";
+
+const pageBreadcrumbs = [
+  {
+    text: "Documentation",
+    href: "/docs",
+  },
+  {
+    text: "Water Management",
+    href: "/docs/water-management",
+  },
+  {
+    text: "LatestValueCard",
+    href: "/docs/water-management/latest-value-card",
+  },
+];
+
+const componentProps = [
+  {
+    name: "label",
+    type: "string",
+    default: "undefined",
+    desc: "The label/title of the card.",
+  },
+  {
+    name: "tsId",
+    type: "string",
+    default: "undefined",
+    desc: "The time series ID of the value to be retrieved.",
+  },
+  {
+    name: "office",
+    type: "string",
+    default: "undefined",
+    desc: "The office code of the data's owning office.",
+  },
+  {
+    name: "digits",
+    type: "number",
+    default: 0,
+    desc: "The number of trailing digits to display after the decimal.",
+  },
+  {
+    name: "className",
+    type: "string",
+    default: "undefined",
+    desc: "Additional classes to add to the card.",
+  },
+];
+
+function CdaLatestValueCardDocs() {
+  return (
+    <DocsPage breadcrumbs={pageBreadcrumbs}>
+      <UsaceBox title="CDA Latest Value Card">
+        {/* Description of the component and what problem it solves */}
+        <div className="gw-pb-6">
+          <Text>
+            The CDA Latest Value Card can be used to display the most recent
+            available data for a specific CWMS time series.
+          </Text>
+        </div>
+        {/* Example usage - remove if not needed */}
+        <H3>Basic Example</H3>
+        <div className="gw-rounded-md gw-border gw-border-dashed gw-px-6 gw-py-3 gw-mb-3">
+          <div className="gw-w-96">
+            <CdaLatestValueCard
+              label="Buckhorn Elevation"
+              office="LRL"
+              tsId="Buckhorn-Lake.Elev.Inst.5Minutes.0.USGS-rev"
+              digits={2}
+            />
+          </div>
+        </div>
+        {/* Example code */}
+        <CodeExample
+          code={`import { LatestValueCard } from "@usace/groundwork";
+
+function Component() {
+  return (
+    <div className="w-96">
+      <CdaLatestValueCard
+        label="Buckhorn Elevation"
+        office="LRL"
+        tsId="Buckhorn-Lake.Elev.Inst.5Minutes.0.USGS-rev"
+        digits={2}
+      />
+    </div>
+  )
+}
+
+export default Component;
+`}
+        />
+        {/* Component props documentation */}
+        <div className="gw-font-bold gw-text-lg gw-pt-6">
+          Component API -{" "}
+          <Code className="gw-p-2">{`<CdaLatestValueCard />`}</Code>
+        </div>
+        <PropsTable propsList={componentProps} />
+      </UsaceBox>
+    </DocsPage>
+  );
+}
+
+export default CdaLatestValueCardDocs;
+export { CdaLatestValueCardDocs };

--- a/src/app-pages/documentation/water-management/latest-value-card.jsx
+++ b/src/app-pages/documentation/water-management/latest-value-card.jsx
@@ -59,7 +59,8 @@ function CdaLatestValueCardDocs() {
         <div className="gw-pb-6">
           <Text>
             The CDA Latest Value Card can be used to display the most recent
-            available data for a specific CWMS time series.
+            available data for a specific CWMS time series. This component
+            assumes that the data has been updated in the past 24 hours.
           </Text>
         </div>
         {/* Example usage - remove if not needed */}

--- a/src/nav-links.js
+++ b/src/nav-links.js
@@ -182,6 +182,11 @@ export default [
         href: "/docs/water-management/data-hooks",
       },
       {
+        id: "latest-value-card",
+        text: "Latest Value Card",
+        href: "/docs/water-management/latest-value-card",
+      },
+      {
         id: "use-cda-catalog-ts",
         text: "useCdaCatalogTS",
         href: "/docs/water-management/use-cda-catalog-ts",

--- a/src/nav-links.js
+++ b/src/nav-links.js
@@ -182,9 +182,9 @@ export default [
         href: "/docs/water-management/data-hooks",
       },
       {
-        id: "latest-value-card",
-        text: "Latest Value Card",
-        href: "/docs/water-management/latest-value-card",
+        id: "cda-latest-value-card",
+        text: "CdaLatestValueCard",
+        href: "/docs/water-management/cda-latest-value-card",
       },
       {
         id: "use-cda-catalog-ts",


### PR DESCRIPTION
Draft of a pretty highly-abstracted card component to display the latest value and timestamp for a provided CDA time series.

I have a mess of ideas on how to lay out the props in my head, so, as promised, I'm going to try to lay them out here and see what sticks.

Right now the component just takes the two required parameters for a CDA TimeSeries request (tsId and office) and leaves the rest as default.  The idea was for this to be a very high-level "plug-and-play" component.  But, this means it uses a default time window of now -> 24 hours ago.  And, I'm just realizing now, returns the default units... So this probably works for a lot of use cases, but sometimes it won't.  So, a few options:
- Have the user pass the full useCdaTimeSeries parameter object (or at least the cdaParams part)
  - This shifts a lot of responsibility to the user, which is good and bad.
  - Ultimately, you're still probably guessing how far back to make the "lookback"
  - This feels a little weird to me.
- Have the user pass the return object from a useCdaTimeSeries request
  - This feels a little better prop-wise, but you're no longer encapsulating the responsibility of the component, which feels a little weird in another way.
  - Still have the issue of not knowing the lookback
- First make a useCdaCatalogTS request to figure out when the most recent value and set your useCdaTimeSeries params based on that
  - Eliminates the time window issue, but now we have a request waterfall.  So it's probably going to be twice as slow.
  - Could potentially add a flag that lets you toggle this, e.g. expectOld?
  - Doesn't fix the other params issue, e.g. units
- Just use the A2W api
  - Certainly the easiest option since the api provides the latest value directly
  - Database is old -- this will change eventually, but probably not a great look for the workshop in my opinion
  - You can only pull data that's hooked up through CMA, which leaves out a lot of potential uses
- Decouple completely from the data request and just have the user provide the value and timestamp
  - Puts more responsibility on the user and isn't nearly as plug-and-play at this point
  - This gets into a whole mess of "how do you handle pending/error states?"
- Have multiple components with varying levels of allowable customization
  - Library gets messy quick -- how do you organize this?

That's a lot of stuff so I'll leave it there.  Curious to hear anyone's ideas / suggestions / opinions on what route to take with this.