### PR TITLE
add min height to the navbar links component

### DIFF
--- a/lib/composite/header/navbar-links.jsx
+++ b/lib/composite/header/navbar-links.jsx
@@ -67,7 +67,7 @@ function NavbarLinksList({ links, ...props }) {
 
 const NavbarLinks = ({ links = [] }) => {
   return (
-    <div className="gw-hidden md:gw-flex gw-flex-row gw-content-center gw-justify-between gw-w-full gw-pr-3">
+    <div className="gw-hidden md:gw-flex gw-flex-row gw-content-center gw-justify-between gw-w-full gw-min-h-12 gw-pr-3">
       <NavbarLinksList links={links} />
     </div>
   );


### PR DESCRIPTION
now it's keeping it from collapsing when empty.