### PR TITLE
46 header nav max width instead of fluid

### DIFF
--- a/lib/components/layout/container.jsx
+++ b/lib/components/layout/container.jsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 function Container({ className, children, fluid }) {
   const containerClass = clsx(
     "gw-w-full gw-mx-auto gw-px-4 gw-box-border",
-    fluid ? "gw-max-w-[100vw]" : "gw-max-w-[1140px]",
+    fluid ? "gw-max-w-screen" : "gw-max-w-screen-2xl",
     className
   );
   return <div className={containerClass}>{children}</div>;

--- a/lib/composite/footer/index.jsx
+++ b/lib/composite/footer/index.jsx
@@ -80,6 +80,7 @@ const defaultOffsiteLinks = [
 ];
 
 function Footer({
+  fluidNav,
   missionText,
   aboutText,
   facebookUrl,
@@ -97,7 +98,7 @@ function Footer({
     <footer className="gw-relative gw-text-footer-light-gray gw-text-sm gw-bg-footer-black gw-border-t-gray-600 gw-border-t-4 gw-pb-[128px]">
       <Essayons />
       <div className="gw-bg-footer-gray gw-pt-8 gw-pb-16">
-        <Container fluid>
+        <Container fluid={fluidNav}>
           <div className="gw-grid gw-grid-cols-12 gw-gap-2">
             <div className="gw-col-span-12 lg:gw-col-span-6">
               <div className="gw-grid gw-grid-cols-12 gw-gap-2">

--- a/lib/composite/header/index.jsx
+++ b/lib/composite/header/index.jsx
@@ -39,7 +39,7 @@ function Header({ links, title, subtitle, navRight, fluidNav }) {
   const [showOverlayLinks, setShowOverlayLinks] = useState(false);
   const navContainerClass = clsx(
     "gw-w-full gw-mx-auto gw-px-4 gw-box-border",
-    fluidNav ? "gw-max-w-[100vw]" : "gw-max-w-[1140px]"
+    fluidNav ? "gw-max-w-screen" : "gw-max-w-screen-2xl"
   );
   return (
     <>

--- a/lib/composite/header/index.jsx
+++ b/lib/composite/header/index.jsx
@@ -22,20 +22,9 @@ function Title({ title = "", subtitle = "" }) {
   );
 }
 
-function Nav({ children }) {
-  return (
-    <nav
-      style={{ order: 1 }}
-      className="gw-flex gw-flex-row gw-relative gw-justify-between gw-content-center gw-bg-nav-black gw-text-white gw-pl-[91px] gw-pr-2 gw-z-80"
-    >
-      {children}
-    </nav>
-  );
-}
-
 function Logo() {
   return (
-    <div className="gw-relative gw-w-[100px] gw-shrink-0 sm:gw-top-3">
+    <div className="gw-relative gw-w-[70px] sm:gw-w-[82px] gw-shrink-0 sm:gw-top-3">
       <a href="/">
         <img className="gw-w-[50px] sm:gw-w-[60px] gw-h-auto" src={usaceLogo} />
       </a>
@@ -60,7 +49,7 @@ function Header({ links, title, subtitle, navRight, fluidNav }) {
             <div className={navContainerClass}>
               <div className="gw-flex gw-justify-between gw-items-center">
                 <Logo />
-                <NavbarLinks links={[links[1]]} />
+                <NavbarLinks links={links} />
                 <span className="gw-flex gw-flex-row-reverse gw-justify-end gw-items-center gw-w-full md:gw-max-w-[300px] gw-mr-2">
                   {navRight ? navRight : null}
                 </span>
@@ -80,7 +69,7 @@ function Header({ links, title, subtitle, navRight, fluidNav }) {
           <div className="gw-min-h-4 gw-py-2 sm:gw-py-0 gw-bg-nav-dark-gray sm:gw-bg-nav-gray">
             <div className={navContainerClass}>
               <div className="gw-flex gw-justify-between gw-items-center">
-                <span className="sm:gw-w-[82px] gw-shrink-0 "></span>
+                <span className="sm:gw-w-[94px] gw-shrink-0 "></span>
                 <Title title={title} subtitle={subtitle} />
               </div>
             </div>

--- a/lib/composite/header/index.jsx
+++ b/lib/composite/header/index.jsx
@@ -4,17 +4,18 @@ import usaceLogo from "../../img/usace-logo-color.svg";
 import { Button } from "../../components/button";
 import { GiHamburgerMenu } from "react-icons/gi";
 import { useState } from "react";
+import clsx from "clsx";
 
 function Title({ title = "", subtitle = "" }) {
   return (
     <div
       style={{ order: 2 }}
-      className="gw-w-full gw-pl-[15px] sm:gw-pl-[100px] gw-pr-[15px] gw-py-3 sm:gw-py-0 gw-bg-nav-dark-gray sm:gw-bg-nav-gray"
+      className="gw-w-full gw-text-white sm:gw-text-usace-black"
     >
-      <span className="gw-text-lg sm:gw-text-sm gw-font-semibold sm:gw-font-bold gw-text-white sm:gw-text-usace-black gw-leading-4 sm:gw-leading-normal gw-block sm:gw-inline gw-mr-1">
+      <span className="gw-text-lg sm:gw-text-sm gw-font-semibold sm:gw-font-bold gw-leading-4 sm:gw-leading-normal gw-block sm:gw-inline gw-mr-1">
         {title}
       </span>
-      <span className="gw-text-md sm:gw-text-sm gw-text-white sm:gw-text-usace-black gw-font-thin sm:gw-font-normal gw-block sm:gw-inline">
+      <span className="gw-text-md sm:gw-text-sm gw-mt-2 sm:gw-mt-0 gw-font-thin sm:gw-font-normal gw-block sm:gw-inline">
         {subtitle}
       </span>
     </div>
@@ -34,40 +35,57 @@ function Nav({ children }) {
 
 function Logo() {
   return (
-    <div className="gw-absolute gw-left-[15px] sm:gw-bottom-[-15px] gw-w-[48px] sm:gw-w-[82px] gw-z-10">
+    <div className="gw-relative gw-w-[100px] gw-shrink-0 sm:gw-top-3">
       <a href="/">
-        <img className="gw-h-[50px] gw-w-auto" src={usaceLogo} />
+        <img className="gw-w-[50px] sm:gw-w-[60px] gw-h-auto" src={usaceLogo} />
       </a>
-      <div className="gw-absolute gw-left-[50px] sm:gw-left-[65px] gw-bottom-[-3px] sm:gw-bottom-[-9px] gw-text-sm gw-text-gray-400">
+      <div className="gw-absolute gw-left-[55px] sm:gw-left-[65px] gw-bottom-[-10px] sm:gw-bottom-[-9px] gw-text-sm gw-text-gray-400">
         ®
       </div>
     </div>
   );
 }
 
-function Header({ links, title, subtitle, navRight }) {
+function Header({ links, title, subtitle, navRight, fluidNav }) {
   const [showOverlayLinks, setShowOverlayLinks] = useState(false);
+  const navContainerClass = clsx(
+    "gw-w-full gw-mx-auto gw-px-4 gw-box-border",
+    fluidNav ? "gw-max-w-[100vw]" : "gw-max-w-[1140px]"
+  );
   return (
     <>
       <header className="gw-flex gw-flex-col gw-w-full gw-sticky gw-top-0 gw-z-20">
-        <Title title={title} subtitle={subtitle} />
-        <Nav>
-          <Logo />
-          <NavbarLinks links={links} />
-          <span className="gw-flex gw-flex-row-reverse gw-justify-end gw-items-center gw-w-full md:gw-max-w-[300px] gw-mr-2">
-            {navRight ? navRight : null}
-          </span>
-          <Button
-            style="plain"
-            color="white"
-            className="md:gw-hidden"
-            onClick={() => {
-              setShowOverlayLinks(true);
-            }}
-          >
-            <GiHamburgerMenu />
-          </Button>
-        </Nav>
+        <div>
+          <div className="gw-min-h-12 gw-bg-nav-black gw-text-white">
+            <div className={navContainerClass}>
+              <div className="gw-flex gw-justify-between gw-items-center">
+                <Logo />
+                <NavbarLinks links={[links[1]]} />
+                <span className="gw-flex gw-flex-row-reverse gw-justify-end gw-items-center gw-w-full md:gw-max-w-[300px] gw-mr-2">
+                  {navRight ? navRight : null}
+                </span>
+                <Button
+                  style="plain"
+                  color="white"
+                  className="md:gw-hidden"
+                  onClick={() => {
+                    setShowOverlayLinks(true);
+                  }}
+                >
+                  <GiHamburgerMenu />
+                </Button>
+              </div>
+            </div>
+          </div>
+          <div className="gw-min-h-4 gw-py-2 sm:gw-py-0 gw-bg-nav-dark-gray sm:gw-bg-nav-gray">
+            <div className={navContainerClass}>
+              <div className="gw-flex gw-justify-between gw-items-center">
+                <span className="sm:gw-w-[82px] gw-shrink-0 "></span>
+                <Title title={title} subtitle={subtitle} />
+              </div>
+            </div>
+          </div>
+        </div>
       </header>
       {showOverlayLinks ? (
         <OverlayLinks

--- a/lib/composite/header/navbar-links.jsx
+++ b/lib/composite/header/navbar-links.jsx
@@ -31,7 +31,7 @@ function NavbarLinkItem({ link, ...props }) {
         <Menu.Items
           static
           as="ul"
-          className="gw-absolute gw-left-0 gw-top-13 gw-width-auto gw-bg-nav-dark-gray"
+          className="gw-absolute gw-left-0 gw-top-13 gw-width-auto gw-bg-nav-dark-gray !gw-z-20"
         >
           {link.children.map((child) => {
             return (

--- a/lib/composite/header/usa-banner/USABanner.jsx
+++ b/lib/composite/header/usa-banner/USABanner.jsx
@@ -13,7 +13,7 @@ const USABanner = ({ fluidNav }) => {
   const [open, setOpen] = useState(false);
   const headerBannerInnerClass = clsx(
     "header_banner_inner",
-    fluidNav ? "gw-max-w-[100vw]" : "gw-px-4 gw-max-w-[1140px]"
+    fluidNav ? "gw-max-w-screen" : "gw-px-4 gw-max-w-screen-2xl"
   );
   return (
     <div

--- a/lib/composite/header/usa-banner/USABanner.jsx
+++ b/lib/composite/header/usa-banner/USABanner.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import clsx from "clsx";
 import "./usa-banner.css";
 import flag from "../../../img/us_flag_small.png";
 import iconDotGov from "../../../img/icon-dot-gov.svg";
@@ -8,14 +9,18 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(" ");
 }
 
-const USABanner = () => {
+const USABanner = ({ fluidNav }) => {
   const [open, setOpen] = useState(false);
+  const headerBannerInnerClass = clsx(
+    "header_banner_inner",
+    fluidNav ? "gw-max-w-[100vw]" : "gw-px-4 gw-max-w-[1140px]"
+  );
   return (
     <div
       id="dnn_ctl03_header_banner_container"
       className="header_banner_container"
     >
-      <span className="header_banner_inner">
+      <div className={headerBannerInnerClass}>
         <div className="header_banner_flag gw-flex gw-items-center gw-justify-start">
           <img src={flag} className="gw-mr-2" />
           An official website of the United States government
@@ -115,7 +120,7 @@ const USABanner = () => {
             </div>
           </div>
         ) : null}
-      </span>
+      </div>
     </div>
   );
 };

--- a/lib/composite/header/usa-banner/usa-banner.css
+++ b/lib/composite/header/usa-banner/usa-banner.css
@@ -26,7 +26,7 @@
 .header_banner_container .header_banner_inner {
   line-height: 1.5;
   margin: 0 auto;
-  max-width: 1400px;
+  /* max-width: 1400px; */
   font-size: 12px;
 }
 
@@ -83,7 +83,7 @@
   flex-direction: column;
   margin: 0 auto;
   max-height: 0;
-  max-width: 1400px;
+  /* max-width: 1400px; */
   overflow: hidden;
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
@@ -128,7 +128,7 @@
 .header_banner_container .header_banner_content {
   font-size: 14px;
   line-height: 26px;
-  max-width: none;
+  /* max-width: none; */
   width: 100%;
   margin-bottom: 10px;
   letter-spacing: 0.5px;

--- a/lib/composite/site-wrapper/index.jsx
+++ b/lib/composite/site-wrapper/index.jsx
@@ -10,6 +10,7 @@ function SiteWrapper({
   usaBanner = true,
   msgBanner: MsgBanner = false,
   title = "US Army Corps of Engineers",
+  fluidNav = false,
   subtitle = "",
   missionText = "",
   aboutText = "",
@@ -34,6 +35,7 @@ function SiteWrapper({
           title={title}
           subtitle={subtitle}
           navRight={navRight}
+          fluidNav={fluidNav}
         />
         {children}
       </div>

--- a/lib/composite/site-wrapper/index.jsx
+++ b/lib/composite/site-wrapper/index.jsx
@@ -41,6 +41,7 @@ function SiteWrapper({
       </div>
       {showFooter && (
         <Footer
+          fluidNav={fluidNav}
           missionText={missionText}
           aboutText={aboutText}
           facebookUrl={facebookUrl}

--- a/lib/composite/site-wrapper/index.jsx
+++ b/lib/composite/site-wrapper/index.jsx
@@ -28,8 +28,8 @@ function SiteWrapper({
   return (
     <div className="gw-grid gw-min-h-[100vh] gw-grid-rows-1fr-auto">
       <div>
-        {usaBanner && <USABanner />}
-        {MsgBanner && <MsgBanner />}
+        {usaBanner && <USABanner fluidNav={fluidNav} />}
+        {MsgBanner && <MsgBanner fluidNav={fluidNav} />}
         <Header
           links={links}
           title={title}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ function App() {
   return (
     <div onClick={getNavHelper((url) => doUpdateHash(url))}>
       <SiteWrapper
+        fluidNav={true}
         links={links}
         usaBanner={true}
         subtitle={`Groundwork React Components v${version}`}


### PR DESCRIPTION
Make it so you can pass a `fluidNav` prop to the SiteWrapper component.  If fluid, then full width, otherwise the default is the constrained width of the `Container` element (1140px I believe)