### PR TITLE
Compliance/508 corrections from IT Scan

### DIFF
--- a/lib/catalyst/avatar.jsx
+++ b/lib/catalyst/avatar.jsx
@@ -31,7 +31,7 @@ export function Avatar({ src = null, square = false, initials, alt = '', classNa
           </text>
         </svg>
       )}
-      {src && <img src={src} alt={alt} />}
+      {src && <img aria-label={alt} src={src} alt={alt} />}
       {/* Add an inset border that sits on top of the image */}
       <span className="gw-ring-1 gw-ring-inset gw-ring-black/5 gw-dark:gw-ring-white/5 gw-forced-colors:gw-outline" gw-aria-hidden="gw-true" />
     </span>

--- a/lib/components/hero.jsx
+++ b/lib/components/hero.jsx
@@ -70,6 +70,7 @@ function Hero({ title, subtitle, image, alt, children, duration_ms = 12000, imgH
         <img
           src={currentImage}
           alt={currentAlt}
+          aria-label={alt} 
           className={`gw-object-cover gw-object-center gw-w-full gw-h-full`}
           style={{height: imgHeight, width: imgWidth}}
         />

--- a/lib/components/layout/usace-box.jsx
+++ b/lib/components/layout/usace-box.jsx
@@ -15,8 +15,7 @@ function UsaceBox({ children, className, title, customTitle }) {
   return (
     <div className={usaceBoxClass}>
       <h2
-        style={{ fontSize: "1.3rem", lineHeight: "1.4rem" }}
-        className="gw-font-bold gw-mb-6"
+        className="gw-font-bold gw-mb-6 gw-text-[1.3rem] gw-h-[1.4rem]"
       >
         {title}
         {CustomTitle && <CustomTitle />}

--- a/lib/components/profile-dropdown.jsx
+++ b/lib/components/profile-dropdown.jsx
@@ -30,6 +30,7 @@ function Gravatar({ email }) {
     <img
       className="gw-h-8 gw-w-8 gw-rounded-full"
       src={gravatarUrl}
+      aria-label="Gravatar profile image"
       alt="Gravatar profile image"
     />
   );

--- a/lib/components/profile-dropdown.jsx
+++ b/lib/components/profile-dropdown.jsx
@@ -52,11 +52,11 @@ function ProfileDropdown({
           {email ? (
             <Gravatar email={email} />
           ) : (
-            <span className="gw-inline-block gw-h-8 gw-w-8 gw-rounded-full gw-overflow-hidden gw-text-nav-black gw-text-xl gw-font-bold gw-bg-nav-gray">
+            <strong className="gw-inline-block gw-h-8 gw-w-8 gw-rounded-full gw-overflow-hidden gw-text-nav-black gw-text-xl gw-bg-nav-gray">
               <span className="gw-align-middle">
                 {username ? username[0].toUpperCase() : "U"}
               </span>
-            </span>
+            </strong>
           )}
         </Menu.Button>
       </div>

--- a/lib/components/table.jsx
+++ b/lib/components/table.jsx
@@ -36,7 +36,7 @@ export function Table({
               !bleed && "sm:gw-px-[--gutter]"
             )}
           >
-            <table className="gw-min-w-full gw-text-left gw-text-sm/6">
+            <table role="presentation" className="gw-min-w-full gw-text-left gw-text-sm/6">
               {children}
             </table>
           </div>
@@ -117,7 +117,9 @@ export function TableCell({ className, children, ...props }) {
   let { bleed, dense, grid, striped } = useContext(TableContext);
   let { href, target, title } = useContext(TableRowContext);
   let [cellRef, setCellRef] = useState(null);
-
+  // TODO: How to handle a table having th for 508. 
+  // INFO: If no thead should the first column have a th
+  // INFO: If a thead is present should the TableCell determine if it is in thead and use the <th> tag?
   return (
     <td
       ref={href ? setCellRef : undefined}

--- a/lib/composite/footer/essayons.jsx
+++ b/lib/composite/footer/essayons.jsx
@@ -4,6 +4,7 @@ function Essayons() {
   return (
     <img
       aria-label="USACE Castle"
+      alt="USACE Castle"
       src={essayons}
       className={`gw-absolute gw-bottom-[56px] gw-left-[50%] gw-h-[125px] gw-w-[112px] gw-ml-[-56px]`}
       role="presentation"

--- a/lib/composite/footer/essayons.jsx
+++ b/lib/composite/footer/essayons.jsx
@@ -3,6 +3,7 @@ import essayons from "../../img/essayonscrest.png";
 function Essayons() {
   return (
     <img
+      aria-label="USACE Castle"
       src={essayons}
       className={`gw-absolute gw-bottom-[56px] gw-left-[50%] gw-h-[125px] gw-w-[112px] gw-ml-[-56px]`}
       role="presentation"

--- a/lib/composite/footer/logo-banner.jsx
+++ b/lib/composite/footer/logo-banner.jsx
@@ -8,13 +8,14 @@ function LogoBanner({ army, usace, rsgis, cwbi }) {
     <div className="gw-flex gw-flex-row gw-justify-center gw-align-middle gw-gap-6 gw-mb-4 gw-mt-4">
       {army && (
         <a href="https://www.army.mil" target="_blank" rel="noopener">
-          <img src={armyLogo} alt="U.S. Army" className="gw-max-h-[75px]" />
+          <img src={armyLogo} aria-label="U.S. Army Logo" alt="U.S. Army" className="gw-max-h-[75px]" />
         </a>
       )}
       {usace && (
         <a href="https://www.usace.army.mil" target="_blank" rel="noopener">
           <img
             src={usaceLogo}
+            aria-label="U.S. Army Corps of Engineers"
             alt="U.S. Army Corps of Engineers"
             className="gw-max-h-[75px] gw-h-[75px] gw-w-auto"
           />
@@ -28,6 +29,7 @@ function LogoBanner({ army, usace, rsgis, cwbi }) {
         >
           <img
             src={rsgisLogo}
+            aria-label="Remote Sensing - GIS Center of Expertise Logo"
             alt="Remote Sensing - GIS Center of Expertise"
             className="gw-max-h-[75px]"
           />
@@ -41,6 +43,7 @@ function LogoBanner({ army, usace, rsgis, cwbi }) {
         >
           <img
             src={cwbiLogo}
+            aria-label="Civil Works Business Intelligence Logo"
             alt="Civil Works Business Intelligence"
             className="gw-max-h-[75px]"
           />

--- a/lib/composite/header/index.jsx
+++ b/lib/composite/header/index.jsx
@@ -12,9 +12,9 @@ function Title({ title = "", subtitle = "" }) {
       style={{ order: 2 }}
       className="gw-w-full gw-text-white sm:gw-text-usace-black"
     >
-      <span className="gw-text-lg sm:gw-text-sm gw-font-semibold sm:gw-font-bold gw-leading-4 sm:gw-leading-normal gw-block sm:gw-inline gw-mr-1">
+      <strong className="gw-font-normal sm:gw-font-bold gw-text-lg sm:gw-text-sm gw-leading-4 sm:gw-leading-normal gw-block sm:gw-inline gw-mr-1">
         {title}
-      </span>
+      </strong>
       <span className="gw-text-md sm:gw-text-sm gw-mt-2 sm:gw-mt-0 gw-font-thin sm:gw-font-normal gw-block sm:gw-inline">
         {subtitle}
       </span>

--- a/lib/composite/header/usa-banner/USABanner.jsx
+++ b/lib/composite/header/usa-banner/USABanner.jsx
@@ -22,7 +22,7 @@ const USABanner = ({ fluidNav }) => {
     >
       <div className={headerBannerInnerClass}>
         <div className="header_banner_flag gw-flex gw-items-center gw-justify-start">
-          <img src={flag} className="gw-mr-2" role="presentation" aria-label="U.S. Government Flag" />
+          <img src={flag} className="gw-mr-2" role="presentation" aria-label="U.S. Government Flag" alt="U.S. Government Flag" />
           An official website of the United States government
           <div className="header_banner_accordion" tabIndex={0}>
             <u
@@ -65,6 +65,7 @@ const USABanner = ({ fluidNav }) => {
             <div className="header_banner_panel_item">
               <img
                 src={iconDotGov}
+                alt="Generic government building icon"
                 aria-label="Generic government building icon"
                 className="gw-h-[50px] gw-w-[50px] gw-mr-4"
               />
@@ -82,6 +83,7 @@ const USABanner = ({ fluidNav }) => {
             <div className="header_banner_panel_item https">
               <img
                 src={iconHttps}
+                alt="HTTPS secure lock icon"
                 aria-label="HTTPS secure lock icon"
                 className="gw-h-[50px] gw-w-[50px] gw-mr-4"
               />

--- a/lib/composite/header/usa-banner/USABanner.jsx
+++ b/lib/composite/header/usa-banner/USABanner.jsx
@@ -22,7 +22,7 @@ const USABanner = ({ fluidNav }) => {
     >
       <div className={headerBannerInnerClass}>
         <div className="header_banner_flag gw-flex gw-items-center gw-justify-start">
-          <img src={flag} className="gw-mr-2" role="presentation" />
+          <img src={flag} className="gw-mr-2" role="presentation" aria-label="U.S. Government Flag" />
           An official website of the United States government
           <div className="header_banner_accordion" tabIndex={0}>
             <u
@@ -65,6 +65,7 @@ const USABanner = ({ fluidNav }) => {
             <div className="header_banner_panel_item">
               <img
                 src={iconDotGov}
+                aria-label="Generic government building icon"
                 className="gw-h-[50px] gw-w-[50px] gw-mr-4"
               />
               <div
@@ -81,6 +82,7 @@ const USABanner = ({ fluidNav }) => {
             <div className="header_banner_panel_item https">
               <img
                 src={iconHttps}
+                aria-label="HTTPS secure lock icon"
                 className="gw-h-[50px] gw-w-[50px] gw-mr-4"
               />
               <div

--- a/lib/composite/header/usa-banner/USABanner.jsx
+++ b/lib/composite/header/usa-banner/USABanner.jsx
@@ -17,7 +17,7 @@ const USABanner = ({ fluidNav }) => {
   );
   return (
     <div
-      className="header_banner_container"
+      className="header_banner_container gw-bg-gov-banner-black gw-text-white"
     >
       <div className={headerBannerInnerClass}>
         <div className="header_banner_flag gw-fill-gov-banner-gray gw-py-1.5 gw-h-12 sm:gw-h-8 gw-px-0 gw-text-sm gw-box-border gw-flex gw-items-center gw-justify-start">
@@ -68,7 +68,7 @@ const USABanner = ({ fluidNav }) => {
                 id="dnn_ctl03_bannerContentLeft"
                 className="header_banner_content gw-text-sm gw-leading-7 gw-w-full gw-mb-2.5 -gw-tracking-tighter"
               >
-                <p className="banner-contentLeft-text mb-0 gw-text-lg">
+                <p className="banner-contentLeft-text mb-0 gw-text-lg gw-text-white">
                   <strong> Official websites use .mil </strong>
                 </p>
                 A <strong>.mil</strong> website belongs to an official U.S.
@@ -86,7 +86,7 @@ const USABanner = ({ fluidNav }) => {
                 id="dnn_ctl03_bannerContentRight"
                 className="header_banner_content gw-text-sm gw-leading-7 gw-w-full gw-mb-2.5 -gw-tracking-tighter"
               >
-                <p className="banner-contentRight-text mb-0 gw-text-lg">
+                <p className="banner-contentRight-text mb-0 gw-text-lg gw-text-white">
                   <strong>Secure .mil websites use HTTPS</strong>
                 </p>
                 <div>

--- a/lib/composite/header/usa-banner/USABanner.jsx
+++ b/lib/composite/header/usa-banner/USABanner.jsx
@@ -12,19 +12,18 @@ function classNames(...classes) {
 const USABanner = ({ fluidNav }) => {
   const [open, setOpen] = useState(false);
   const headerBannerInnerClass = clsx(
-    "header_banner_inner",
+    "header_banner_inner sm:gw-my-0 sm:gw-mx-auto sm:gw-font-sm",
     fluidNav ? "gw-max-w-screen" : "gw-px-4 gw-max-w-screen-2xl"
   );
   return (
     <div
-      id="dnn_ctl03_header_banner_container"
       className="header_banner_container"
     >
       <div className={headerBannerInnerClass}>
-        <div className="header_banner_flag gw-flex gw-items-center gw-justify-start">
+        <div className="header_banner_flag gw-fill-gov-banner-gray gw-py-1.5 gw-h-12 sm:gw-h-8 gw-px-0 gw-text-sm gw-box-border gw-flex gw-items-center gw-justify-start">
           <img src={flag} className="gw-mr-2" role="presentation" aria-label="U.S. Government Flag" alt="U.S. Government Flag" />
           An official website of the United States government
-          <div className="header_banner_accordion" tabIndex={0}>
+          <div className="header_banner_accordion gw-text-gov-banner-gray gw-border-0 gw-cursor-pointer gw-text-sm gw-outline-none gw-text-left gw-transition-all gw-duration-300 gw-ease-out gw-my-0 gw-ms-1 gw-me-2.5 sm:gw-me-0 gw-inline-block focus:outline-5 focus:outline-focus-ring" tabIndex={0}>
             <u
               onClick={() => {
                 setOpen(!open);
@@ -33,8 +32,8 @@ const USABanner = ({ fluidNav }) => {
               Here's how you know
               <span
                 className={classNames(
-                  "expand-more-container",
-                  open ? "active" : ""
+                  "expand-more-container gw-inline-block gw-align-top",
+                  open ? "gw-transform gw-rotate-180" : ""
                 )}
               >
                 <svg
@@ -42,6 +41,7 @@ const USABanner = ({ fluidNav }) => {
                   height="24"
                   viewBox="0 0 24 24"
                   width="24"
+                  className="gw-inline-block gw-relative gw-transition-all gw-delay-300 gw-ease-out gw-align-middle gw-h-[18px] gw-w-[18px]"
                 >
                   <path d="M0 0h24v24H0z" fill="none"></path>
                   <path
@@ -55,12 +55,7 @@ const USABanner = ({ fluidNav }) => {
         </div>
         {open ? (
           <div
-            className="header_banner_panel active active"
-            style={{
-              paddingTop: "24px",
-              paddingBottom: "18px",
-              maxHeight: "328px",
-            }}
+            className="header_banner_panel gw-flex gw-flex-col md:gw-flex-row gw-my-0 gw-mx-auto gw-overflow-hidden gw-pt-6 gw-pb-4 gw-max-h-[328px] active"
           >
             <div className="header_banner_panel_item">
               <img
@@ -71,9 +66,9 @@ const USABanner = ({ fluidNav }) => {
               />
               <div
                 id="dnn_ctl03_bannerContentLeft"
-                className="header_banner_content"
+                className="header_banner_content gw-text-sm gw-leading-7 gw-w-full gw-mb-2.5 -gw-tracking-tighter"
               >
-                <p className="banner-contentLeft-text">
+                <p className="banner-contentLeft-text mb-0 gw-text-lg">
                   <strong> Official websites use .mil </strong>
                 </p>
                 A <strong>.mil</strong> website belongs to an official U.S.
@@ -89,9 +84,9 @@ const USABanner = ({ fluidNav }) => {
               />
               <div
                 id="dnn_ctl03_bannerContentRight"
-                className="header_banner_content"
+                className="header_banner_content gw-text-sm gw-leading-7 gw-w-full gw-mb-2.5 -gw-tracking-tighter"
               >
-                <p className="banner-contentRight-text">
+                <p className="banner-contentRight-text mb-0 gw-text-lg">
                   <strong>Secure .mil websites use HTTPS</strong>
                 </p>
                 <div>
@@ -99,16 +94,17 @@ const USABanner = ({ fluidNav }) => {
                   A{" "}
                   <strong>
                     lock (
-                    <span className="header_banner_icon_lock">
+                    <span className="header_banner_icon_lock gw-inline-block gw-h-[15px] gw-w-[15px] gw-my-0 gw-mx-2 gw-relative">
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         width="52"
                         height="64"
                         viewBox="0 0 52 64"
+                        className="gw-fill-black gw-h-[15px] gw-w-[15px]"
                       >
                         <title>lock </title>
                         <path
-                          className="icon_lock"
+                          className="icon_lock gw-fill-white"
                           fillRule="evenodd"
                           d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
                         ></path>{" "}

--- a/lib/composite/header/usa-banner/usa-banner.css
+++ b/lib/composite/header/usa-banner/usa-banner.css
@@ -1,3 +1,8 @@
+body {
+  -webkit-transition: padding-top 200ms ease-out;
+  transition: padding-top 200ms ease-out;
+}
+
 .header_banner_container,
 .header_banner_container .header_banner_content .banner-contentLeft-text,
 .header_banner_container .header_banner_content .banner-contentRight-text {
@@ -8,55 +13,6 @@
   padding: 0 20px;
   position: relative;
   z-index: 10;
-}
-
-.header_banner_container .header_banner_flag {
-  padding: 6px 0;
-  height: 50px;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-@media screen and (min-width: 544px) {
-  .header_banner_container .header_banner_flag {
-    height: 30px;
-  }
-}
-
-.header_banner_container .header_banner_inner {
-  line-height: 1.5;
-  margin: 0 auto;
-  /* max-width: 1400px; */
-  font-size: 12px;
-}
-
-.header_banner_container .header_banner_accordion {
-  border: 0;
-  color: #aebfd4;
-  cursor: pointer;
-  font-size: 13px;
-  outline: none;
-  text-align: left;
-  -webkit-transition: all 0.4s ease-out;
-  transition: all 0.4s ease-out;
-  margin: 0 4px 0 10px;
-  display: inline-block;
-}
-
-.header_banner_container .header_banner_accordion:focus-visible {
-  outline: 5px auto -webkit-focus-ring-color;
-}
-
-@media screen and (min-width: 367px) {
-  .header_banner_container .header_banner_accordion {
-    margin: 0 4px 0 0;
-  }
-}
-
-@media screen and (min-width: 518px) {
-  .header_banner_container .header_banner_accordion {
-    margin: 0 4px 0 10px;
-  }
 }
 
 .header_banner_container .header_banner_accordion svg {
@@ -71,31 +27,6 @@
 
 .header_banner_container .header_banner_accordion svg .expand-more {
   fill: #aebfd4;
-}
-
-.header_banner_container .header_banner_panel {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0 auto;
-  max-height: 0;
-  /* max-width: 1400px; */
-  overflow: hidden;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-}
-
-@media screen and (min-width: 768px) {
-  .header_banner_container .header_banner_panel {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
 }
 
 .header_banner_container .header_banner_panel_item {
@@ -125,21 +56,6 @@
   }
 }
 
-.header_banner_container .header_banner_content {
-  font-size: 14px;
-  line-height: 26px;
-  /* max-width: none; */
-  width: 100%;
-  margin-bottom: 10px;
-  letter-spacing: 0.5px;
-}
-
-.header_banner_container .header_banner_content .banner-contentLeft-text,
-.header_banner_container .header_banner_content .banner-contentRight-text {
-  margin-bottom: 0;
-  font-size: 18px;
-}
-
 .header_banner_container .header_banner_dotgov:before {
   background-image: url(/icon-dot-gov.svg);
   background-size: 50px;
@@ -160,40 +76,7 @@
   width: 50px;
 }
 
-.header_banner_container .header_banner_icon_lock {
-  display: inline-block;
-  height: 15px;
-  position: relative;
-  width: 15px;
-  margin: 0 8px;
-}
-
-.header_banner_container .header_banner_icon_lock svg {
-  height: 15px;
-  width: 15px;
-  fill: black;
-}
-
-body {
-  -webkit-transition: padding-top 200ms ease-out;
-  transition: padding-top 200ms ease-out;
-}
-
-.expand-more-container.active {
-  display: inline-block;
-  -webkit-transform: rotate(180deg);
-  transform: rotate(180deg);
-  vertical-align: text-top;
-}
-
 .header_banner_container {
   background-color: #15263b;
-  color: #fff;
-}
-.icon_lock {
-  fill: #fff;
-}
-.header_banner_container .header_banner_content .banner-contentLeft-text,
-.header_banner_container .header_banner_content .banner-contentRight-text {
   color: #fff;
 }

--- a/lib/composite/header/usa-banner/usa-banner.css
+++ b/lib/composite/header/usa-banner/usa-banner.css
@@ -3,12 +3,6 @@ body {
   transition: padding-top 200ms ease-out;
 }
 
-.header_banner_container,
-.header_banner_container .header_banner_content .banner-contentLeft-text,
-.header_banner_container .header_banner_content .banner-contentRight-text {
-  color: #fff;
-}
-
 .header_banner_container {
   padding: 0 20px;
   position: relative;
@@ -74,9 +68,4 @@ body {
   height: 50px;
   margin-right: 10px;
   width: 50px;
-}
-
-.header_banner_container {
-  background-color: #15263b;
-  color: #fff;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,7 @@ export default {
         "footer-light-gray": "#ccc",
         "usace-black": "#18181b",
         "gov-banner-gray": "#aebfd4",
+        "gov-banner-black": "#15263b"
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,7 @@ export default {
         "footer-gray": "#333",
         "footer-light-gray": "#ccc",
         "usace-black": "#18181b",
+        "gov-banner-gray": "#aebfd4",
       },
     },
   },


### PR DESCRIPTION
# Initial pass through for 508 compliance

Walked through the provided IT scan and attempted to correct what appeared to be Groundwork specific items. 

All corrections in this PR are an attempt to correct one or more 508 findings. 

## The commits in order are:
- Add aria-label to all tags
- Ensure `alt` on all tags
- Create role tag for table, add note about how to handle the `th` vs `td` finding for a do-out
- Convert span tags that have **bold** font weight to the semantic <strong> tag
- Convert all CSS classes with static font sizes in the `usa-banner.css` file to dynamic
  - Remove classes from the index file
  - Leave the class names in the event endusers are using these for targeting (Making this a potentially `minor` bump)
- Use tailwind classes to handle the background colors for browser default consideration