### PR TITLE
Remove static size to prevent long text overlapping

### DIFF
--- a/lib/components/layout/usace-box.jsx
+++ b/lib/components/layout/usace-box.jsx
@@ -15,7 +15,7 @@ function UsaceBox({ children, className, title, customTitle }) {
   return (
     <div className={usaceBoxClass}>
       <h2
-        className="gw-font-bold gw-mb-6 gw-text-[1.3rem] gw-h-[1.4rem]"
+        className="gw-font-bold gw-mb-5 gw-text-[1.3rem]"
       >
         {title}
         {CustomTitle && <CustomTitle />}


### PR DESCRIPTION
# Follow-up for #97 

### Addresses:
- #99 

Missed an issue where text would overlap in the sidebar when a user had long text in the UsaceBox component's title. 

This was an oversight when testing in Groundwork because Groundwork's text is `"Content"` and did not come up until a district had "Water Control Data System" in the box (for example)

BEFORE:
![image](https://github.com/user-attachments/assets/9eccd3fc-55f7-4d87-8ce3-8096a47a2811)

AFTER FIX:
![image](https://github.com/user-attachments/assets/9aaa12aa-ea58-4135-965b-6c95d3ed911e)

Groundwork display after fix:
![image](https://github.com/user-attachments/assets/f35e7690-df6d-45fd-894a-17164269ad90)


Note: this was changed to "water management" after this example screenshot was taken.