### PR TITLE
Add Progress Load Bar Component

### DIFF
--- a/lib/components/display/progress-bar.jsx
+++ b/lib/components/display/progress-bar.jsx
@@ -33,7 +33,7 @@ const ProgressBar = ({
           className
         )}
         style={{
-          width: `${progress}%`,
+          width: `${Math.round(progress)}%`,
           transition: `width ${baseDuration}ms ease-in-out`,
         }}
         {...props}

--- a/lib/components/display/progress-bar.jsx
+++ b/lib/components/display/progress-bar.jsx
@@ -1,0 +1,49 @@
+import gwMerge from "../../gw-merge";
+
+const ProgressBar = ({
+  progress,
+  hideOnDone = true,
+  showProgress,
+  bgColor = "gw-bg-blue-600",
+  textColor = "gw-text-blue-100",
+  className,
+  baseDuration = 300,
+  ...props
+}) => {
+  if (typeof progress !== "number") {
+    throw new Error("Progress is expected to be a number!");
+  }
+  // Prevent unexpected CSS situations
+  if (progress < 0) progress = 0;
+  if (progress > 100) progress = 100;
+
+  return (
+    <div
+      className={gwMerge(
+        `gw-w-full gw-bg-gray-200 gw-rounded-full dark:gw-bg-gray-700`,
+        hideOnDone && progress === 100 ? "gw-hidden" : ""
+      )}
+    >
+      <div
+        className={gwMerge(
+          bgColor,
+          textColor,
+          showProgress && "gw-min-h-4",
+          `gw-text-xs gw-font-medium gw-text-center gw-p-0.5 gw-leading-none gw-rounded-full`,
+          className
+        )}
+        style={{
+          width: `${progress}%`,
+          transition: `width ${baseDuration}ms ease-in-out`,
+        }}
+        {...props}
+      >
+        {/* Show the progress text after 5% of the total to ensure there is room for the text to display */}
+        {showProgress && progress > 5 ? `${progress.toFixed(0)} %` : ""}
+      </div>
+    </div>
+  );
+};
+
+export { ProgressBar };
+export default ProgressBar;

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -15,6 +15,7 @@ export * from "./components/table";
 export * from "./components/display/card";
 export * from "./components/profile-dropdown";
 export { Skeleton } from "./components/display/skeleton";
+export { ProgressBar } from "./components/display/progress-bar";
 
 // composite components
 export { Header } from "./composite/header";

--- a/src/app-bundles/routes-bundle.js
+++ b/src/app-bundles/routes-bundle.js
@@ -25,6 +25,7 @@ import TabDocs from "../app-pages/documentation/types/tab";
 import BadgeDocs from "../app-pages/documentation/display/badge";
 import AccordionDocs from "../app-pages/documentation/display/accordion";
 import CardDocs from "../app-pages/documentation/display/card";
+import ProgressDocs from "../app-pages/documentation/display/progress-bar";
 import NotFound from "../app-pages/404";
 import GenericButtonsDocs from "../app-pages/documentation/buttons/generic-buttons";
 import OkCancelDocs from "../app-pages/documentation/buttons/ok-cancel";
@@ -79,6 +80,7 @@ export default createRouteBundle(
     "/docs/display/table": TableDocs,
     "/docs/display/card": CardDocs,
     "/docs/display/accordion": AccordionDocs,
+    "/docs/display/progress-bar": ProgressDocs,
     "/docs/forms": Forms,
     "/docs/forms/dropdown": DropdownDocs,
     "/docs/forms/fieldset": FieldsetDocs,

--- a/src/app-pages/documentation/display/progress-bar.jsx
+++ b/src/app-pages/documentation/display/progress-bar.jsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { UsaceBox, Code, Text, ProgressBar, Button } from "../../../../lib";
+import { CodeExample } from "../../../app-components/code-example";
+import PropsTable from "../../../app-components/props-table";
+import DocsPage from "../_docs-page";
+
+const pageBreadcrumbs = [
+  {
+    text: "Documentation",
+    href: "/docs",
+  },
+  {
+    text: "Display",
+    href: "/docs/display",
+  },
+  {
+    text: "Progress Bar",
+    href: "/docs/display/progress-bar",
+  },
+];
+
+const componentProps_ProgressBar = [
+  {
+    name: "progress",
+    type: "number",
+    default: "0",
+    desc: "The progress of the bar. Must be a number between 0 and 100.",
+  },
+  {
+    name: "hideOnDone",
+    type: "boolean",
+    default: "true",
+    desc: "Whether to hide the progress bar when the progress reaches 100.",
+  },
+  {
+    name: "showProgress",
+    type: "boolean",
+    default: "true",
+    desc: "Whether to show the progress percentage text on the bar.",
+  },
+  {
+    name: "bgColor",
+    type: "string",
+    default: "gw-bg-blue-600",
+    desc: "The background color of the progress bar.",
+  },
+  {
+    name: "textColor",
+    type: "string",
+    default: "gw-text-blue-100",
+    desc: "The text color of the progress bar.",
+  },
+  {
+    name: "baseDuration",
+    type: "number",
+    default: "300",
+    desc: "The base duration in milliseconds for the progress bar. The time of animation between frames.",
+  },
+  {
+    name: "className",
+    type: "string",
+    default: "undefined",
+    desc: "Additional classes to be added to the progress bar.",
+  },
+];
+
+function ProgressDocs() {
+  const [progress, setProgress] = useState(100);
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (progress < 100) setProgress(progress + 1 > 100 ? 0 : progress + 1);
+    }, 100);
+  }, [progress]);
+  return (
+    <DocsPage breadcrumbs={pageBreadcrumbs}>
+      <UsaceBox title="Progress Bar">
+        <div className="gw-pb-6">
+          <Text className="gw-mb-3">
+            The Progress Bar component is a simple way to display the progress
+            of a task or process.
+          </Text>
+          <Text>
+            It can be used to show the progress of a file upload, a form
+            submission, or any other task that has a defined start and end
+            point.
+          </Text>
+        </div>
+        {/* Example usage - remove if not needed */}
+        <div className="gw-rounded-md gw-border gw-border-dashed gw-px-6 gw-py-3 gw-mb-3">
+          {progress == 100 ? (
+            <div>
+              Done! 🎉{" "}
+              <Button
+                title="Restart the loader example!"
+                onClick={() => {
+                  setProgress(0);
+                }}
+              >
+                Restart
+              </Button>
+            </div>
+          ) : (
+            <ProgressBar progress={progress} showProgress={true} />
+          )}
+        </div>
+        {/* Example code */}
+        <CodeExample
+          code={`import { Badge, BadgeButton } from "@usace/groundwork";
+
+function Component() {
+    import { ProgressBar, Button } from "@usace/groundwork";
+    const [progress, setProgress] = useState(0);
+
+    useEffect(() => {
+        setTimeout(() => {
+            setProgress(progress + 1 > 100 ? 0 : progress + 1);
+        }, 100);
+  }, [progress]);
+  
+  if (progress == 100) return (
+        <div>
+            Done! 🎉{" "}
+            <Button
+                title="Restart the loader example!"
+                onClick={() => {
+                setProgress(0);
+                }}
+            >
+                Restart
+            </Button>
+        </div>
+    )
+    return (
+        <ProgressBar
+        progress={progress}
+        showProgress={true}
+        />
+    )
+}
+
+export default Component;
+`}
+        />
+        {/* Component props documentation */}
+        <div className="gw-font-bold gw-text-lg gw-pt-6">
+          Component API - <Code className="gw-p-2">{`<ProgressBar />`}</Code>
+        </div>
+        <PropsTable propsList={componentProps_ProgressBar} />
+      </UsaceBox>
+    </DocsPage>
+  );
+}
+
+export default ProgressDocs;
+export { ProgressDocs };

--- a/src/nav-links.js
+++ b/src/nav-links.js
@@ -159,6 +159,11 @@ export default [
         text: "Card",
         href: "/docs/display/card",
       },
+      {
+        id: "progress-bar",
+        text: "Progress Bar",
+        href: "/docs/display/progress-bar",
+      },
     ],
   },
   {


### PR DESCRIPTION
Add a new `<ProgressBar />` component. 

Allows user control of color, progress, and if text is to be displayed. Also passes through all other props to the loader tag. 

Considered using [the native progress tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress) but opted to create a custom one for us to fully have control of styling it with TailwindCSS.


Doc path is set to (under display)
`/docs/display/progress-bar`
