### PR TITLE
React 19 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.14.4",
             "license": "MIT",
             "dependencies": {
-                "@headlessui/react": "^2.1.8",
+                "@headlessui/react": "^2.2.0",
                 "@tailwindcss/forms": "^0.5.9",
                 "internal-nav-helper": "^3.1.0",
                 "react-icons": "^5.0.1",
@@ -18,8 +18,8 @@
                 "redux-bundler-react": "^1.2.0"
             },
             "devDependencies": {
-                "@types/react": "^18.2.43",
-                "@types/react-dom": "^18.2.17",
+                "@types/react": "^18.3.0",
+                "@types/react-dom": "^18.3.0",
                 "@vitejs/plugin-react": "^4.2.1",
                 "autoprefixer": "^10.4.17",
                 "eslint": "^8.55.0",
@@ -33,8 +33,8 @@
                 "vitest": "^2.1.1"
             },
             "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
+                "react": "^18.2.0 || ^19.0.0",
+                "react-dom": "^18.2.0 || ^19.0.0"
             }
         },
         "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "test": "vitest"
     },
     "dependencies": {
-        "@headlessui/react": "^2.1.8",
+        "@headlessui/react": "^2.2.0",
         "@tailwindcss/forms": "^0.5.9",
         "internal-nav-helper": "^3.1.0",
         "react-icons": "^5.0.1",
@@ -39,12 +39,12 @@
         "redux-bundler-react": "^1.2.0"
     },
     "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
     },
     "devDependencies": {
-        "@types/react": "^18.2.43",
-        "@types/react-dom": "^18.2.17",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.17",
         "eslint": "^8.55.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,11 +21,12 @@ export default defineConfig(({ mode }) => {
           entry: "lib/index.jsx",
         },
         rollupOptions: {
-          external: ["react", "react-dom"],
+          external: ['react', 'react-dom', 'react/jsx-runtime'],
           output: {
             globals: {
               react: "React",
               "react-dom": "ReactDOM",
+              'react/jsx-runtime': 'ReactJsxRuntime',
             },
           },
         },


### PR DESCRIPTION
Bump `@headlessui/react` and change rollup options for `react/jsx-runtime` to support React 19.