### PR TITLE
Bump Z-Index for Sidebar

### DIFF
--- a/lib/components/buttons/popover.jsx
+++ b/lib/components/buttons/popover.jsx
@@ -5,6 +5,7 @@ import {
   VscChevronUp,
   VscChevronDown,
 } from "react-icons/vsc";
+import gwMerge from "../../gw-merge";
 
 const AVAIL_DIRECTIONS = ["right", "left", "top", "bottom"];
 
@@ -44,17 +45,17 @@ function PopoutMenu({
   return (
     <Popover
       name="gw-popout-menu"
-      className={`gw-z-[${
-        level * 10
-      }] gw-relative gw-cursor-not-allowed gw-select-none ${className}`}
+      style={{ zIndex: level * 10 + 10 }}
+      className={gwMerge(
+        "gw-relative gw-cursor-not-allowed gw-select-none",
+        className
+      )}
     >
       {({ open }) => (
         <>
           <PopoverButton
-            className={`gw-z-[${
-              level * 10 + 1
-            }] gw-inline-flex gw-w-full gw-items-center gw-justify-between gw-leading-6 gw-ps-1 focus:gw-outline-none`}
-          >
+            style={{ zIndex: level * 10 + 11 }}
+            className="gw-inline-flex gw-w-full gw-items-center gw-justify-between gw-leading-6 gw-ps-1 focus:gw-outline-none">
             <span>{title}</span>
             <ChevronIcon
               aria-hidden="true"
@@ -71,7 +72,7 @@ function PopoutMenu({
               } gw-max-w-[50vw] gw-mt-2 gw-w-56 gw-shrink gw-rounded-xl gw-bg-white gw-text-sm gw-leading-6 gw-text-gray-900 gw-shadow-lg gw-ring-1 gw-ring-gray-900/5 ${
                 directionClasses[direction]
               }`}
-              style={{ zIndex: level * 10 + 2 }}
+              style={{ zIndex: level * 30 + 12 }}
             >
               {({ close }) => (
                 <div

--- a/lib/composite/sidebar/index.jsx
+++ b/lib/composite/sidebar/index.jsx
@@ -1,5 +1,4 @@
 import { UsaceBox, PopoutMenu } from "../..";
-import { VscChevronRight } from "react-icons/vsc";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import Dropdown from "../../components/form/dropdown";
 import { useRef } from "react";


### PR DESCRIPTION
# Issue
User was attempting to add a scroll page body and ran into z-index issues. Bumping z-index by 10 to help ensure sidebar is on top. 

Would be curious if we should bump by 100? but not sure what modal was set to. 


# Summary

This pull request refactors the `PopoutMenu` component in `lib/components/buttons/popover.jsx` to improve maintainability and consistency by introducing the `gwMerge` utility for class name management and adjusting z-index calculations. Additionally, it removes an unused import from `lib/composite/sidebar/index.jsx`.

## Refactoring of `PopoutMenu` component:

* **Introduction of `gwMerge` utility**: Replaced inline template literals for class names with the `gwMerge` utility to simplify and standardize class name management. (`lib/components/buttons/popover.jsx`, [[1]](diffhunk://#diff-fa8a58243338695165f594dcb18ee2fef8c468b063371cad5bf6638bd527602eR8) [[2]](diffhunk://#diff-fa8a58243338695165f594dcb18ee2fef8c468b063371cad5bf6638bd527602eL47-R58)
* **Z-index adjustments**: Updated z-index calculations to use inline `style` attributes for consistency and adjusted the values for better layering. (`lib/components/buttons/popover.jsx`, [[1]](diffhunk://#diff-fa8a58243338695165f594dcb18ee2fef8c468b063371cad5bf6638bd527602eL47-R58) [[2]](diffhunk://#diff-fa8a58243338695165f594dcb18ee2fef8c468b063371cad5bf6638bd527602eL74-R75)

