### PR TITLE
Checkboxes Fieldset

### DIFF
--- a/lib/components/form/checkboxes.jsx
+++ b/lib/components/form/checkboxes.jsx
@@ -33,7 +33,13 @@ function Checkboxes({ content, legend, className, ...props }) {
                     item?.name ||
                     `checkbox-${index}-${legend}-description`
                   }
-                  className="gw-col-start-1 gw-row-start-1 gw-appearance-none gw-rounded gw-border gw-border-gray-300 gw-bg-white checked:gw-border-indigo-600 checked:gw-bg-indigo-600 indeterminate:gw-border-indigo-600 indeterminate:gw-bg-indigo-600 focus-visible:gw-outline focus-visible:gw-outline-2 focus-visible:gw-outline-offset-2 focus-visible:gw-outline-indigo-600 disabled:gw-border-gray-300 disabled:gw-bg-gray-100 disabled:checked:gw-bg-gray-100 forced-colors:gw-appearance-auto"
+                  className={gwMerge(
+                    "gw-col-start-1 gw-row-start-1 gw-appearance-none gw-rounded gw-border gw-border-gray-300 gw-bg-white",
+                    "checked:gw-border-indigo-600 checked:gw-bg-indigo-600 indeterminate:gw-border-indigo-600 indeterminate:gw-bg-indigo-600",
+                    "focus-visible:gw-outline focus-visible:gw-outline-2 focus-visible:gw-outline-offset-2 focus-visible:gw-outline-indigo-600 disabled:gw-border-gray-300",
+                    "disabled:gw-bg-gray-100 disabled:checked:gw-bg-gray-100 forced-colors:gw-appearance-auto",
+                    item?.inputProps?.className
+                  )}
                 />
                 <svg
                   fill="none"

--- a/lib/components/form/checkboxes.jsx
+++ b/lib/components/form/checkboxes.jsx
@@ -1,0 +1,86 @@
+import gwMerge from "../../gw-merge";
+
+function Checkboxes({ content, legend, className, ...props }) {
+  if (!content || !Array.isArray(content) || content.length === 0) {
+    console.warn(
+      "Checkboxes component requires a non-empty array of content items."
+    );
+    return null;
+  }
+  return (
+    <fieldset className={className} {...props}>
+      {legend && <legend className="gw-sr-only">{legend}</legend>}
+      {content.map((item, index) => (
+        <div
+          key={[index, "checkbox", legend].join("-")}
+          className="gw-space-y-5"
+        >
+          <div className="gw-flex gw-gap-3">
+            <div className="gw-flex gw-h-6 gw-shrink-0 gw-items-center">
+              <div className="gw-group gw-grid gw-size-4 gw-grid-cols-1">
+                <input
+                  defaultChecked={item?.defaultChecked || false}
+                  disabled={item?.disabled || false}
+                  onClick={item?.onClick}
+                  onChange={item?.onChange}
+                  {...item?.inputProps}
+                  id={item?.id || `checkbox-${index}-${legend}`}
+                  name={item?.name || `checkbox-${index}-${legend}`}
+                  type="checkbox"
+                  aria-describedby={
+                    item?.ariaDescribedBy ||
+                    item?.name ||
+                    `checkbox-${index}-${legend}-description`
+                  }
+                  className="gw-col-start-1 gw-row-start-1 gw-appearance-none gw-rounded gw-border gw-border-gray-300 gw-bg-white checked:gw-border-indigo-600 checked:gw-bg-indigo-600 indeterminate:gw-border-indigo-600 indeterminate:gw-bg-indigo-600 focus-visible:gw-outline focus-visible:gw-outline-2 focus-visible:gw-outline-offset-2 focus-visible:gw-outline-indigo-600 disabled:gw-border-gray-300 disabled:gw-bg-gray-100 disabled:checked:gw-bg-gray-100 forced-colors:gw-appearance-auto"
+                />
+                <svg
+                  fill="none"
+                  viewBox="0 0 14 14"
+                  className="gw-pointer-events-none gw-col-start-1 gw-row-start-1 gw-size-3.5 gw-self-center gw-justify-self-center gw-stroke-white group-has-[:disabled]:gw-stroke-gray-950/25"
+                >
+                  <path
+                    d="M3 8L6 11L11 3.5"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="gw-opacity-0 gw-group-has-[:checked]:gw-opacity-100"
+                  />
+                  <path
+                    d="M3 7H11"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="gw-opacity-0 group-has-[:indeterminate]:gw-opacity-100"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div className="text-sm/6">
+              {item?.label && (
+                <label
+                  htmlFor="comments"
+                  className="gw-font-medium gw-text-gray-900"
+                  {...item?.labelProps}
+                >
+                  {item.label}
+                </label>
+              )}
+              {item?.description && (
+                <p
+                  id={`comments-${item?.id}-description`}
+                  className={gwMerge("gw-text-gray-500", item?.className)}
+                >
+                  {item.description}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+    </fieldset>
+  );
+}
+
+export default Checkboxes;
+export { Checkboxes };

--- a/lib/components/form/checkboxes.jsx
+++ b/lib/components/form/checkboxes.jsx
@@ -1,4 +1,5 @@
 import gwMerge from "../../gw-merge";
+import { Fieldset } from "./fieldset";
 
 function Checkboxes({ content, legend, className, ...props }) {
   if (!content || !Array.isArray(content) || content.length === 0) {
@@ -8,7 +9,7 @@ function Checkboxes({ content, legend, className, ...props }) {
     return null;
   }
   return (
-    <fieldset className={className} {...props}>
+    <Fieldset className={className} {...props}>
       {legend && <legend className="gw-sr-only">{legend}</legend>}
       {content.map((item, index) => (
         <div
@@ -78,7 +79,7 @@ function Checkboxes({ content, legend, className, ...props }) {
           </div>
         </div>
       ))}
-    </fieldset>
+    </Fieldset>
   );
 }
 

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -47,3 +47,4 @@ export * from "./components/form/dropdown";
 export { Input } from "./components/form/input";
 export * from "./components/form/fieldset";
 export * from "./components/form/textarea";
+export * from "./components/form/checkboxes";

--- a/src/app-bundles/routes-bundle.js
+++ b/src/app-bundles/routes-bundle.js
@@ -49,6 +49,7 @@ import PackageMaintenance from "../app-pages/documentation/getting-started/packa
 import LinkProviderDocs from "../app-pages/documentation/navigation/link-provider";
 import DividerDocs from "../app-pages/documentation/display/divider";
 import ModalDocs from "../app-pages/documentation/display/modal";
+import CheckboxesDocs from "../app-pages/documentation/forms/checkboxes";
 
 export default createRouteBundle(
   {
@@ -96,6 +97,7 @@ export default createRouteBundle(
     "/docs/forms/color-input": ColorInputDocs,
     "/docs/forms/date-time-inputs": DateTimeInputDocs,
     "/docs/forms/file-input": FileInputDocs,
+    "/docs/forms/checkboxes": CheckboxesDocs,
     "/docs/types": Types,
     "/docs/types/link": LinkDocs,
     "/docs/types/tab": TabDocs,

--- a/src/app-pages/documentation/forms/checkboxes.jsx
+++ b/src/app-pages/documentation/forms/checkboxes.jsx
@@ -1,0 +1,256 @@
+import { UsaceBox, Code, Text, Button, Divider, Badge } from "../../../../lib";
+import { CodeExample } from "../../../app-components/code-example";
+import PropsTable from "../../../app-components/props-table";
+import DocsPage from "../_docs-page";
+import { Checkboxes } from "../../../../lib/components/form/checkboxes";
+import { useState, useMemo } from "react";
+
+const pageBreadcrumbs = [
+  { text: "Documentation", href: "/docs" },
+  { text: "Forms", href: "/docs/forms" },
+  { text: "Checkboxes", href: "/docs/forms/checkboxes" },
+];
+
+const checkboxItemProps = [
+  {
+    name: "label",
+    type: "string",
+    default: "''",
+    desc: "The label text shown next to the checkbox.",
+  },
+  {
+    name: "description",
+    type: "string",
+    default: "''",
+    desc: "Optional description displayed under the label.",
+  },
+  {
+    name: "defaultChecked",
+    type: "boolean",
+    default: "false",
+    desc: "Whether the checkbox is initially checked.",
+  },
+  {
+    name: "disabled",
+    type: "boolean",
+    default: "false",
+    desc: "Disable this checkbox.",
+  },
+  {
+    name: "onChange",
+    type: "function",
+    default: "undefined",
+    desc: "Callback fired on checkbox change.",
+  },
+  {
+    name: "id",
+    type: "string",
+    default: "auto-generated",
+    desc: "Unique identifier for the checkbox.",
+  },
+  {
+    name: "name",
+    type: "string",
+    default: "auto-generated",
+    desc: "Name attribute for the checkbox.",
+  },
+  {
+    name: "ariaDescribedBy",
+    type: "string",
+    default: "auto-generated",
+    desc: "ARIA description id for accessibility.",
+  },
+  {
+    name: "className",
+    type: "string",
+    default: "''",
+    desc: "Additional class names to apply to the label element. Overrides default styles.",
+  },
+  {
+    name: "inputProps",
+    type: "object",
+    default: "{}",
+    desc: "Additional props spread onto the underlying <input> element.",
+  },
+  {
+    name: "labelProps",
+    type: "object",
+    default: "{}",
+    desc: "Additional props spread onto the <label> wrapper container.",
+  },
+];
+
+const componentProps_Checkboxes = [
+  {
+    name: "content",
+    type: "Array<CheckboxItem>",
+    default: "[]",
+    desc: "Array of checkbox item objects (see CheckboxItem API below).",
+  },
+  {
+    name: "legend",
+    type: "string",
+    default: "undefined",
+    desc: "The screen-reader-only label for the group of checkboxes.",
+  },
+  {
+    name: "className",
+    type: "string",
+    default: "''",
+    desc: "Additional classes to apply to the fieldset wrapper.",
+  },
+];
+
+function CheckboxesDocs() {
+  const [checkedItems, setCheckedItems] = useState({ opt1: true, opt2: false });
+  const clearAll = () => setCheckedItems({ opt1: false, opt2: false });
+  const allChecked = Object.values(checkedItems).every(Boolean);
+
+  const exampleContent = useMemo(
+    () => [
+      {
+        id: "opt-1",
+        label: "Option 1",
+        description: "Enable feature one",
+        defaultChecked: checkedItems.opt1,
+        onChange: (e) =>
+          setCheckedItems((prev) => ({ ...prev, opt1: e.target.checked })),
+        inputProps: { title: "Checkbox for option 1" },
+      },
+      {
+        id: "opt-2",
+        label: "Option 2",
+        description: "Enable feature two",
+        defaultChecked: checkedItems.opt2,
+        onChange: (e) =>
+          setCheckedItems((prev) => ({ ...prev, opt2: e.target.checked })),
+        inputProps: { title: "Checkbox for option 2" },
+        labelProps: { className: "gw-text-blue-400 gw-text-xl" },
+      },
+    ],
+    [checkedItems]
+  );
+
+  return (
+    <DocsPage breadcrumbs={pageBreadcrumbs}>
+      <UsaceBox title="Checkboxes">
+        <div className="gw-pb-6">
+          <Text>
+            The <Code>{"<Checkboxes />"}</Code> component renders a group of
+            styled checkboxes with accessible markup. Each checkbox can be
+            customized through the <Code>content</Code> prop which takes an
+            array of checkbox metadata.
+          </Text>
+        </div>
+        <div className="gw-rounded-md gw-border gw-border-dashed gw-px-6 gw-py-3 gw-mb-3 gw-w-[50%]">
+          <Checkboxes
+            key={JSON.stringify(checkedItems)}
+            legend="Checkbox Example"
+            content={exampleContent}
+          />
+          <div className="gw-mt-4">
+            <Button
+              title="Clear all selected options"
+              onClick={clearAll}
+              color={allChecked ? "red" : "blue"}
+            >
+              Clear All
+            </Button>
+            <div className="gw-mt-2 gw-text-sm">
+              <strong>Current State:</strong> {JSON.stringify(checkedItems)}
+            </div>
+          </div>
+        </div>
+        <CodeExample
+          code={`import { useState, useMemo } from "react";
+import { Checkboxes, Button } from "@usace/groundwork";
+
+function Component() {
+  const [checkedItems, setCheckedItems] = useState({
+    opt1: true,
+    opt2: false,
+  });
+
+  const clearAll = () => setCheckedItems({ opt1: false, opt2: false });
+  const allChecked = Object.values(checkedItems).every(Boolean);
+
+  const content = useMemo(() => [
+    {
+      id: "opt-1",
+      label: "Option 1",
+      description: "Enable feature one",
+      defaultChecked: checkedItems.opt1,
+      onChange: (e) => setCheckedItems((prev) => ({ ...prev, opt1: e.target.checked })),
+      inputProps: { title: "Checkbox for option 1" },
+    },
+    {
+      id: "opt-2",
+      label: "Option 2",
+      description: "Enable feature two",
+      defaultChecked: checkedItems.opt2,
+      onChange: (e) => setCheckedItems((prev) => ({ ...prev, opt2: e.target.checked })),
+      inputProps: { title: "Checkbox for option 2" },
+      labelProps: { className: "text-blue-400 text-xl" },
+    },
+  ], [checkedItems]);
+
+  return (
+    <>
+      <Checkboxes key={JSON.stringify(checkedItems)} legend="Checkbox Example" content={content} />
+      <Button onClick={clearAll} color={allChecked ? "red" : "default"}>Clear All</Button>
+      <div className="mt-2 text-sm">
+        <strong>Current State:</strong> {JSON.stringify(checkedItems)}
+      </div>
+    </>
+  );
+}
+
+export default Component;`}
+        />
+        <Divider className="gw-mt-6 gw-mb-4" text="Checkbox Details" />
+        <Text className="gw-mb-4">
+          The <Code>{"<Checkboxes />"}</Code> component requires an array of
+          checkbox items passed to the <Code>content</Code> prop.
+        </Text>
+        <Badge color="blue" className="gw-mb-4 gw-ms-1">
+          Each item <em>should</em> include at least a <Code>label</Code> and an{" "}
+          <Code>id</Code> and an <Code>onChange</Code> handler for
+          interactivity.
+        </Badge>
+        <CodeExample
+          code={`<Checkboxes
+  legend="Checkbox Example"
+  content={[
+    {
+      id: "opt-1",
+      label: "Option 1",
+      description: "Enable feature one",
+      defaultChecked: true,
+      onChange: (e) => alert("Option 1 changed:", e.target.checked),
+      inputProps: { title: "Checkbox for option 1" },
+      labelProps: { "data-testid": "label-1" },
+    },
+  ]}
+/>`}
+        />
+        <Text className="gw-my-4">
+          Use <Code>inputProps</Code> and <Code>labelProps</Code> to forward
+          additional attributes to the rendered checkbox input and the
+          surrounding label container respectively.
+        </Text>
+        <div className="gw-font-bold gw-text-lg gw-pt-6">
+          Component API - <Code className="gw-p-2">{`<Checkboxes />`}</Code>
+        </div>
+        <PropsTable propsList={componentProps_Checkboxes} />
+        <div className="gw-font-bold gw-text-lg gw-pt-6">
+          Checkbox Item API -{" "}
+          <Code className="gw-p-2">{`<CheckboxItem />`}</Code>
+        </div>
+        <PropsTable propsList={checkboxItemProps} />
+      </UsaceBox>
+    </DocsPage>
+  );
+}
+
+export default CheckboxesDocs;
+export { CheckboxesDocs };

--- a/src/nav-links.js
+++ b/src/nav-links.js
@@ -187,6 +187,11 @@ export default [
     href: "/docs/forms",
     children: [
       {
+        id: "checkboxes",
+        text: "Checkboxes",
+        href: "/docs/forms/checkboxes",
+      },
+      {
         id: "forms-dropdown",
         text: "Dropdown",
         href: "/docs/forms/dropdown",


### PR DESCRIPTION
Adds a new checkbox fieldset with customization options per 

- #137 

You can provide a list of checkbox content to render as many as you need. 

Use multiple <Checkboxes /> to create many fieldsets. 

![image](https://github.com/user-attachments/assets/c9a231b5-a3cc-49c2-b666-75453459e0cd)

Added additional states and example content around the Checkboxes to provide a more complete example of its use. 