### PR TITLE
168 support target blank on link component and in link object definition

### DIFF
--- a/lib/composite/sidebar/index.jsx
+++ b/lib/composite/sidebar/index.jsx
@@ -39,6 +39,7 @@ function renderPopoutMenu({
         <Link
           key={link.id}
           href={link.href}
+          target={link.target}
           className="gw-z-20 gw-flex gw-items-center gw-px-1"
         >
           {link.text}
@@ -49,6 +50,7 @@ function renderPopoutMenu({
             <Link
               key={link.id}
               href={link.href}
+              target={link.target}
               className={`gw-sticky gw-top-0 gw-z-20 gw-flex gw-items-center gw-gap-1 gw-p-2 gw-border-b-[1px] gw-border-b-gray-200 gw-bg-gray-100 gw-font-bold ${
                 isSelected ? "gw-bg-gray-100 gw-rounded" : ""
               }`}
@@ -87,7 +89,7 @@ function renderRegularLinks(link, selectedPath, level = 0) {
   }
   return (
     <div key={link.id}>
-      <Link href={link.href}>
+      <Link href={link.href} target={link.target}>
         <div
           className={`gw-text-lg ${
             level === 0 ? "gw-font-bold" : ""
@@ -150,13 +152,22 @@ function Sidebar({
               mobileNav.current.click();
             }}
             options={combinedLinks.map((link, idx) => (
-              <option key={idx + link?.href + "-mobile-sidebar"} value={link.href} className="gw-pl-2">
+              <option
+                key={idx + link?.href + "-mobile-sidebar"}
+                value={link.href}
+                className="gw-pl-2"
+              >
                 {`${"\u00A0".repeat(link.level * 2)}${link.text}`}
               </option>
             ))}
           />
           {/* Hidden anchor tag to trigger mobile nav for compatibility */}
-          <Link className="hidden" href="#" ref={mobileNav} aria-hidden="true"></Link>
+          <Link
+            className="hidden"
+            href="#"
+            ref={mobileNav}
+            aria-hidden="true"
+          ></Link>
         </div>
       </UsaceBox>
     );

--- a/src/app-pages/documentation/navigation/sidebar.jsx
+++ b/src/app-pages/documentation/navigation/sidebar.jsx
@@ -53,7 +53,7 @@ const componentProps = [
       }
     ]`,
     default: "null",
-    desc: "An array of objects to be used as links in the header. Each object should have an id, text, and href. Setting the href to null will create a disabled link",
+    desc: "An array of objects to be used as links in the header. Each object should have an id, text, and href. Setting the href to null will create a disabled link. Optionally add a prop of 'target'='_blank' to open the link in a new tab.",
   },
   {
     name: "id",

--- a/src/app-pages/documentation/types/link.jsx
+++ b/src/app-pages/documentation/types/link.jsx
@@ -21,6 +21,12 @@ const linkProps = [
     default: "''",
     desc: "The text of the link.",
   },
+  {
+    name: "target",
+    type: "string",
+    default: "undefined",
+    desc: "Set to '_blank' to open the link in a new tab.",
+  },
 ];
 
 const pageBreadcrumbs = [


### PR DESCRIPTION
This handles `target="_blank"` support for the sidebar, there are likely other places where `<Link />` is used where we should explicitly pass the target prop, but wanted to get this out since it was blocking progress.