### PR TITLE
Bump Modal to Account for sidebar z-index increase

### DIFF
--- a/lib/components/display/modal.jsx
+++ b/lib/components/display/modal.jsx
@@ -33,7 +33,7 @@ function Modal({
     <Dialog
       open={opened}
       onClose={onClose}
-      className={gwMerge("gw-relative", "gw-z-50", className)}
+      className={gwMerge("gw-relative", "gw-z-[200]", className)}
     >
       <DialogBackdrop className="gw-fixed gw-inset-0 gw-bg-black/30" />
       <div className="gw-fixed gw-inset-0 gw-w-screen gw-overflow-auto gw-p-4">


### PR DESCRIPTION
This PR will ensure the modal is not overlapped by the sidebar text:

<img width="1483" height="1695" alt="image" src="https://github.com/user-attachments/assets/8927679c-909b-45dc-9fd1-6fdf3ebcd3f7" />

Updated to increase z-index from 50 to 200. 

Current pattern i'm going towards of lowest to highest Z-index priority:
Body < Header/Footer < Sidebar < Modal

Previously the Sidebar had a z-index in the 10s but it was determined this competed with other components (Table). The sidebar was bumped to 100, but the Modal was not also increased (from 50). 

After increasing modal to 200 and testing with the page sidebar set to "popout" (it was fine in normal)

<img width="1500" height="1655" alt="image" src="https://github.com/user-attachments/assets/465bb8c0-843f-4f36-9c3e-14ddbc34dde1" />


Tested with mobile aspect ratio. 


Reported by @adamscarberry on SAM site