### PR TITLE
256 library has groundworkcss instead of stylecss in latest builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,18 @@
       "import": "./dist/groundwork.es.js",
       "require": "./dist/groundwork.umd.cjs"
     },
+    "./groundwork.css": {
+      "import": "./dist/groundwork.css",
+      "require": "./dist/groundwork.css"
+    },
+    "./style.css": {
+      "import": "./dist/groundwork.css",
+      "require": "./dist/groundwork.css"
+    },
+    "./dist/style.css": {
+      "import": "./dist/groundwork.css",
+      "require": "./dist/groundwork.css"
+    },
     "./dist/*.css": {
       "import": "./dist/*.css",
       "require": "./dist/*.css"

--- a/src/app-pages/documentation/getting-started/adding-tailwind.jsx
+++ b/src/app-pages/documentation/getting-started/adding-tailwind.jsx
@@ -112,7 +112,7 @@ export default defineConfig({
           <Code className="!gw-font-bold">./src/App.jsx</Code>
           <CodeExample
             code={`import { SiteWrapper, Container, UsaceBox } from "@usace/groundwork";
-import "@usace/groundwork/dist/style.css";
+import "@usace/groundwork/dist/groundwork.css";
 
 function App() {
   return (

--- a/src/app-pages/documentation/getting-started/client-side-routing.jsx
+++ b/src/app-pages/documentation/getting-started/client-side-routing.jsx
@@ -388,7 +388,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
           <CodeExample
             code={`import { useConnect } from "redux-bundler-hook";
 import { SiteWrapper, Container } from "@usace/groundwork";
-import "@usace/groundwork/dist/style.css";
+import "@usace/groundwork/dist/groundwork.css";
 
 function App() {
 const { route: Route } = useConnect("selectRoute");
@@ -441,7 +441,7 @@ export default App;`}
             code={`import { useConnect } from "redux-bundler-hook";
 import { getNavHelper } from "internal-nav-helper";
 import { SiteWrapper, Container } from "@usace/groundwork";
-import "@usace/groundwork/dist/style.css";
+import "@usace/groundwork/dist/groundwork.css";
 
 function App() {
   const { route: Route, doUpdateUrl } = useConnect(

--- a/src/app-pages/documentation/getting-started/quick-start-guide.jsx
+++ b/src/app-pages/documentation/getting-started/quick-start-guide.jsx
@@ -156,7 +156,7 @@ npm run dev`}
           <Code className="!gw-font-bold">./src/App.jsx</Code>
           <CodeExample
             code={`import { SiteWrapper, Container, UsaceBox } from "@usace/groundwork";
-import "@usace/groundwork/dist/style.css";
+import "@usace/groundwork/dist/groundwork.css";
 
 function App() {
   return (

--- a/src/app-pages/documentation/index.jsx
+++ b/src/app-pages/documentation/index.jsx
@@ -67,12 +67,12 @@ function Docs() {
         </div>
         <div className="gw-flex gw-flex-row gw-justify-start gw-space-between gw-items-center gw-gap-2 gw-mt-3 gw-mb-3">
           <Code className="gw-block gw-p-1 gw-px-2">
-            import "@usace/groundwork/dist/style.css"
+            import "@usace/groundwork/dist/groundwork.css"
           </Code>
-          <CopyButton text={`import "@usace/groundwork/dist/style.css"`} />
+          <CopyButton text={`import "@usace/groundwork/dist/groundwork.css"`} />
         </div>
         <Text>
-          Make sure to import style.css from Groundwork into your top-level
+          Make sure to import groundwork.css from Groundwork into your top-level
           component (i.e. App.jsx), then go build stuff with the components
         </Text>
       </UsaceBox>

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,12 @@ export default defineConfig(({ mode }) => {
         rollupOptions: {
           external: ["react", "react-dom", "react/jsx-runtime"],
           output: {
+            assetFileNames: (assetInfo) => {
+              if (assetInfo.name?.endsWith(".css")) {
+                return "groundwork.css";
+              }
+              return "[name][extname]";
+            },
             globals: {
               react: "React",
               "react-dom": "ReactDOM",


### PR DESCRIPTION
Uses `groundwork.css` going forward

Updated docs to reflect this

If a user has `style.css` now and they bump to latest it should work without them having to use `groundwork.css`. 

If we ever want to enforce style.css we may want to come up with a way to throw an error. 

Some kind of deprecation css class in only `style.css` that JS reads on load to say "style.css is no longer used >link to issue<". 

Patch bump since this should work both ways (style or groundwork css)

