### PR TITLE
Fix sidebar layering below header

### DIFF
--- a/lib/composite/header/index.jsx
+++ b/lib/composite/header/index.jsx
@@ -49,7 +49,7 @@ function Header({ links, title, subtitle, navRight, fluidNav, homeUrl }) {
   );
   return (
     <>
-      <header className="gw-flex gw-flex-col gw-w-full gw-sticky gw-top-0 gw-z-20">
+      <header className="gw-flex gw-flex-col gw-w-full gw-sticky gw-top-0 gw-z-[150]">
         <div>
           <div className="gw-min-h-12 gw-bg-nav-black gw-text-white">
             <div className={navContainerClass}>

--- a/lib/composite/header/overlay-links.jsx
+++ b/lib/composite/header/overlay-links.jsx
@@ -51,7 +51,7 @@ function OverlayLinks({ links = [], onClose }) {
     }
   };
   return (
-    <div className="gw-fixed gw-top-0 gw-left-0 gw-h-full gw-right-0 gw-bg-nav-black gw-bg-opacity-90 gw-z-50">
+    <div className="gw-fixed gw-top-0 gw-left-0 gw-h-full gw-right-0 gw-bg-nav-black gw-bg-opacity-90 gw-z-[200]">
       <div className="gw-flex gw-justify-end">
         <Button style="plain" color="white" size="lg" onClick={handleClose}>
           <VscClose />


### PR DESCRIPTION
## Summary

- Issue reported that the sidebar overlaps the header

## Checklist

Sidebar items no longer overlap the header

And popup items in page will be above header where applicable
<img width="911" height="365" alt="image" src="https://github.com/user-attachments/assets/9caa1987-edb5-475f-a686-1a41838ae202" />



## Release impact

- Minor doc update, not to the library itself. Does not need a version bump but I think it's required currently? 