### PR TITLE
Improve package output for tree shaking

### DIFF
--- a/lib/composite/footer/essayons.jsx
+++ b/lib/composite/footer/essayons.jsx
@@ -1,6 +1,26 @@
-import essayons from "../../img/essayonscrest.png";
+import { useEffect, useState } from "react";
 
 function Essayons() {
+  const [essayons, setEssayons] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    import("../../img/essayonscrest.png").then((module) => {
+      if (!cancelled) {
+        setEssayons(module.default);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!essayons) {
+    return null;
+  }
+
   return (
     <img
       aria-label="USACE Castle"

--- a/lib/composite/footer/logo-banner.jsx
+++ b/lib/composite/footer/logo-banner.jsx
@@ -1,17 +1,45 @@
-import armyLogo from "../../img/armystar-logo-rb.svg";
-import army250Logo from "../../img/Army-250-year-logo.png";
-import usaceLogo from "../../img/usace-logo-color.svg";
-import usace250Logo from "../../img/USACE-250-year-logo.png";
-import rsgisLogo from "../../img/rsgis-logo.png";
-import cwbiLogo from "../../img/cwbi-logo.png";
+import { useEffect, useState } from "react";
+
+const logoLoaders = {
+  army: () => import("../../img/armystar-logo-rb.svg"),
+  army250: () => import("../../img/Army-250-year-logo.png"),
+  usace: () => import("../../img/usace-logo-color.svg"),
+  usace250: () => import("../../img/USACE-250-year-logo.png"),
+  rsgis: () => import("../../img/rsgis-logo.png"),
+  cwbi: () => import("../../img/cwbi-logo.png"),
+};
+
+function LazyLogo({ loader, ...props }) {
+  const [src, setSrc] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loader().then((module) => {
+      if (!cancelled) {
+        setSrc(module.default);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loader]);
+
+  if (!src) {
+    return null;
+  }
+
+  return <img src={src} {...props} />;
+}
 
 function LogoBanner({ army, army250, usace, usace250, rsgis, cwbi }) {
   return (
     <div className="gw-flex gw-flex-row gw-justify-center gw-align-middle gw-gap-6 gw-mb-4 gw-mt-4">
       {army && (
         <a href="https://www.army.mil" target="_blank" rel="noopener">
-          <img
-            src={armyLogo}
+          <LazyLogo
+            loader={logoLoaders.army}
             aria-label="U.S. Army Logo"
             alt="U.S. Army"
             className="gw-max-h-[75px]"
@@ -20,8 +48,8 @@ function LogoBanner({ army, army250, usace, usace250, rsgis, cwbi }) {
       )}
       {army250 && (
         <a href="https://www.army.mil" target="_blank" rel="noopener">
-          <img
-            src={army250Logo}
+          <LazyLogo
+            loader={logoLoaders.army250}
             aria-label="U.S. Army 250 Year Anniversary Logo"
             alt="U.S. Army"
             className="gw-max-h-[75px]"
@@ -30,8 +58,8 @@ function LogoBanner({ army, army250, usace, usace250, rsgis, cwbi }) {
       )}
       {usace && (
         <a href="https://www.usace.army.mil" target="_blank" rel="noopener">
-          <img
-            src={usaceLogo}
+          <LazyLogo
+            loader={logoLoaders.usace}
             aria-label="U.S. Army Corps of Engineers"
             alt="U.S. Army Corps of Engineers"
             className="gw-max-h-[75px] gw-h-[75px] gw-w-auto"
@@ -40,8 +68,8 @@ function LogoBanner({ army, army250, usace, usace250, rsgis, cwbi }) {
       )}
       {usace250 && (
         <a href="https://www.usace.army.mil" target="_blank" rel="noopener">
-          <img
-            src={usace250Logo}
+          <LazyLogo
+            loader={logoLoaders.usace250}
             aria-label="U.S. Army Corps of Engineers"
             alt="U.S. Army Corps of Engineers"
             className="gw-max-h-[75px] gw-h-[75px] gw-w-auto"
@@ -54,8 +82,8 @@ function LogoBanner({ army, army250, usace, usace250, rsgis, cwbi }) {
           target="_blank"
           rel="noopener"
         >
-          <img
-            src={rsgisLogo}
+          <LazyLogo
+            loader={logoLoaders.rsgis}
             aria-label="Remote Sensing - GIS Center of Expertise Logo"
             alt="Remote Sensing - GIS Center of Expertise"
             className="gw-max-h-[75px]"
@@ -68,8 +96,8 @@ function LogoBanner({ army, army250, usace, usace250, rsgis, cwbi }) {
           target="_blank"
           rel="noopener"
         >
-          <img
-            src={cwbiLogo}
+          <LazyLogo
+            loader={logoLoaders.cwbi}
             aria-label="Civil Works Business Intelligence Logo"
             alt="Civil Works Business Intelligence"
             className="gw-max-h-[75px]"

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -1,6 +1,3 @@
-// bundle tailwind
-import "./styles.css";
-
 // utilities
 export { gwMerge } from "./gw-merge";
 

--- a/lib/style-entry.js
+++ b/lib/style-entry.js
@@ -1,0 +1,1 @@
+import "./styles.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react-icons": "^5.0.1",
         "redux-bundler": "^28.1.0",
         "redux-bundler-hook": "^1.0.3",
-        "redux-bundler-react": "^1.2.0"
+        "redux-bundler-react": "^1.2.0",
+        "tailwind-merge": "^2.5.2"
       },
       "devDependencies": {
         "@lhci/cli": "^0.15.1",
@@ -32,7 +33,6 @@
         "lint-staged": "^16.1.4",
         "postcss": "^8.4.33",
         "prettier": "^3.6.2",
-        "tailwind-merge": "^2.5.2",
         "tailwindcss": "^3.4.1",
         "typescript": "^6.0.3",
         "vite": "^8.1.3",
@@ -894,9 +894,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -914,9 +911,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -934,9 +928,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -954,9 +945,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -974,9 +962,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -994,9 +979,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5499,9 +5481,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5523,9 +5502,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5547,9 +5523,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5571,9 +5544,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8146,7 +8116,6 @@
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "files": [
     "dist"
   ],
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
       "import": "./dist/es/index.js",
@@ -74,7 +77,7 @@
   "scripts": {
     "dev": "vite",
     "build": "npm run build-lib && npm run build-docs",
-    "build-lib": "vite build -m lib",
+    "build-lib": "vite build -m lib && vite build -m css",
     "build-docs": "vite build",
     "lhci:prep": "node scripts/extract-routes.js",
     "lhci:run": "rmdir /s /q .lighthouseci 2>nul & npx @lhci/cli autorun --config=.lighthouserc.gen.json --verbose & node scripts/lhci-index.js",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,50 @@
     "url": "git+https://github.com/USACE/groundwork.git"
   },
   "main": "./dist/groundwork.umd.cjs",
-  "module": "./dist/groundwork.es.js",
+  "module": "./dist/es/index.js",
   "files": [
     "dist"
   ],
   "exports": {
     ".": {
-      "import": "./dist/groundwork.es.js",
+      "import": "./dist/es/index.js",
       "require": "./dist/groundwork.umd.cjs"
+    },
+    "./components/*": {
+      "import": "./dist/es/components/*.js"
+    },
+    "./components/buttons/*": {
+      "import": "./dist/es/components/buttons/*.js"
+    },
+    "./components/display/*": {
+      "import": "./dist/es/components/display/*.js"
+    },
+    "./components/form/*": {
+      "import": "./dist/es/components/form/*.js"
+    },
+    "./components/layout/*": {
+      "import": "./dist/es/components/layout/*.js"
+    },
+    "./components/navigation/*": {
+      "import": "./dist/es/components/navigation/*.js"
+    },
+    "./composite/*": {
+      "import": "./dist/es/composite/*.js"
+    },
+    "./composite/footer/*": {
+      "import": "./dist/es/composite/footer/*.js"
+    },
+    "./composite/header/*": {
+      "import": "./dist/es/composite/header/*.js"
+    },
+    "./composite/site-wrapper/*": {
+      "import": "./dist/es/composite/site-wrapper/*.js"
+    },
+    "./hooks/*": {
+      "import": "./dist/es/hooks/*.js"
+    },
+    "./utils/*": {
+      "import": "./dist/es/utils/*.js"
     },
     "./groundwork.css": {
       "import": "./dist/groundwork.css",
@@ -60,7 +96,8 @@
     "react-icons": "^5.0.1",
     "redux-bundler": "^28.1.0",
     "redux-bundler-hook": "^1.0.3",
-    "redux-bundler-react": "^1.2.0"
+    "redux-bundler-react": "^1.2.0",
+    "tailwind-merge": "^2.5.2"
   },
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0",
@@ -80,7 +117,6 @@
     "lint-staged": "^16.1.4",
     "postcss": "^8.4.33",
     "prettier": "^3.6.2",
-    "tailwind-merge": "^2.5.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^6.0.3",
     "vite": "^8.1.3",

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,18 @@ import path from "path";
 import fs from "fs";
 
 const LHCI_PREFIX = process.env.LHCI_PREFIX || "http://localhost:5173/";
+const externalPackages = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+];
+const isExternalPackage = (id) =>
+  externalPackages.some((name) => id === name || id.startsWith(`${name}/`));
+const libraryAssetFileNames = (assetInfo) => {
+  if (assetInfo.name?.endsWith(".css")) {
+    return "groundwork.css";
+  }
+  return "assets/[name][extname]";
+};
 
 function RoutesToLHCIPlugin() {
   return {
@@ -41,24 +53,35 @@ export default defineConfig(({ mode }) => {
       build: {
         lib: {
           name: "Groundwork",
-          fileName: (format) => `groundwork.${format}.js`,
+          fileName: (format) =>
+            format === "umd" ? "groundwork.umd.cjs" : "index.js",
           entry: "lib/index.jsx",
+          formats: ["es", "umd"],
         },
         rollupOptions: {
-          external: ["react", "react-dom", "react/jsx-runtime"],
-          output: {
-            assetFileNames: (assetInfo) => {
-              if (assetInfo.name?.endsWith(".css")) {
-                return "groundwork.css";
-              }
-              return "[name][extname]";
+          external: isExternalPackage,
+          output: [
+            {
+              format: "es",
+              dir: "dist",
+              preserveModules: true,
+              preserveModulesRoot: "lib",
+              entryFileNames: "es/[name].js",
+              chunkFileNames: "es/chunks/[name]-[hash].js",
+              assetFileNames: libraryAssetFileNames,
             },
-            globals: {
-              react: "React",
-              "react-dom": "ReactDOM",
-              "react/jsx-runtime": "ReactJsxRuntime",
+            {
+              format: "umd",
+              name: "Groundwork",
+              entryFileNames: "groundwork.umd.cjs",
+              assetFileNames: libraryAssetFileNames,
+              globals: {
+                react: "React",
+                "react-dom": "ReactDOM",
+                "react/jsx-runtime": "ReactJsxRuntime",
+              },
             },
-          },
+          ],
         },
       },
     };

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,15 @@ const libraryAssetFileNames = (assetInfo) => {
   }
   return "assets/[name][extname]";
 };
+const removeCssEntrypointPlugin = (fileName) => ({
+  name: "remove-css-entrypoint",
+  closeBundle() {
+    const filePath = path.resolve("dist", fileName);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  },
+});
 
 function RoutesToLHCIPlugin() {
   return {
@@ -82,6 +91,28 @@ export default defineConfig(({ mode }) => {
               },
             },
           ],
+        },
+      },
+    };
+  }
+
+  if (mode === "css") {
+    console.log("Building library CSS");
+    return {
+      plugins: [react(), tailwindcss(), removeCssEntrypointPlugin("style.js")],
+      publicDir: false,
+      build: {
+        emptyOutDir: false,
+        lib: {
+          entry: "lib/style-entry.js",
+          name: "GroundworkStyles",
+          fileName: () => "style.js",
+          formats: ["es"],
+        },
+        rollupOptions: {
+          output: {
+            assetFileNames: libraryAssetFileNames,
+          },
         },
       },
     };


### PR DESCRIPTION
## Summary

Improves the library package output so consumers can import smaller parts of Groundwork without pulling the whole bundle:

- publish preserved ESM modules alongside the existing UMD build
- expose component, composite, hook, and utility subpaths
- move CSS to an explicit stylesheet entry
- lazy-load heavier footer image assets

## Bundle check

Package pack size:

| Package | Before | After |
| --- | ---: | ---: |
| Packed tarball | 4.65 MB | 4.55 MB |
| Unpacked package | 7.45 MB | 7.05 MB |

Representative downstream bundle:

| Import | Before | After | Gzip before | Gzip after |
| --- | ---: | ---: | ---: | ---: |
| `Button` from `@usace/groundwork` | 368.9 KB | 244.0 KB | 115.1 KB | 75.7 KB |

## Validation

- `npm run build-lib`
- `npm run build`
- packed the library and tested representative downstream bundles

Related: #191, #218, #221, #179